### PR TITLE
Update Kafka version to 4.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
         with:
           go-version: 1.22.x
 
-      - name: Install Kafka
+      - name: Fetch latest release of Kafka && extract it
         run: |
-          wget --progress=dot:giga https://dlcdn.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz
-          tar -xzf kafka_2.13-3.8.0.tgz
-          sudo mv kafka_2.13-3.8.0/ /usr/local/kafka
+          wget --progress=dot:giga https://media.githubusercontent.com/media/codecrafters-io/build-your-own-kafka/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
+          tar -xzf kafka_2.13-4.0.0-SNAPSHOT.tgz
+          sudo mv kafka_2.13-4.0.0-SNAPSHOT/ /usr/local/kafka
           export PATH=$PATH:/usr/local/kafka/bin
 
       - name: Set up Python


### PR DESCRIPTION
This pull request updates the Kafka version used in our CI pipeline to 4.0.0-SNAPSHOT. The previous version was 3.8.0. This update ensures that we are using our own Kafka release from our descriptions repository.