### PR TITLE
Fix error message in topicUUID check for stagef3

### DIFF
--- a/internal/stagef3.go
+++ b/internal/stagef3.go
@@ -95,7 +95,7 @@ func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	if topicResponse.Topic != UUID {
-		return fmt.Errorf("Expected Topic to be empty, got %v", topicResponse.Topic)
+		return fmt.Errorf("Expected Topic UUID to match UUID from request, got %v", topicResponse.Topic)
 	}
 	logger.Successf("✓ Topic UUID: %v", topicResponse.Topic)
 


### PR DESCRIPTION
This pull request fixes an error message in the topicUUID check for stagef3. Previously, the error message incorrectly stated that the expected topic UUID should be empty, but it should actually match the UUID from the request. This PR updates the error message to reflect the correct expectation.