### PR TITLE
Refactor ClusterMetadataPayload interface

### DIFF
--- a/protocol/api/cluster_metadata_payloads.go
+++ b/protocol/api/cluster_metadata_payloads.go
@@ -9,22 +9,37 @@ import (
 )
 
 //lint:ignore U1000, these are not used in the codebase currently
-type ClusterMetadataPayload struct {
+type ClusterMetadataRecordValue struct {
 	FrameVersion int8
 	Type         int8
 	Version      int8
-	Data         ClusterMetadataPayloadDataRecord
+	Data         []byte
 }
 
-type ClusterMetadataPayloadDataRecord interface {
-	isPayloadRecord()
+func (v ClusterMetadataRecordValue) Encode() []byte {
+	return []byte{}
 }
 
-type BeginTransactionRecord struct {
+type BeginTransactionRecordValue struct {
 	Name string
 }
 
-func (b *BeginTransactionRecord) isPayloadRecord() {}
+func (b *BeginTransactionRecordValue) Encode() []byte {
+	encoder := encoder.RealEncoder{}
+	encoder.Init(make([]byte, 4096))
+
+	encoder.PutUVarint(1) // taggedFieldCount
+	// Encode all the fields
+
+	encodedData := encoder.Bytes()[:encoder.Offset()]
+
+	return ClusterMetadataRecordValue{
+		FrameVersion: 1,
+		Type:         0,
+		Version:      0,
+		Data:         encodedData,
+	}.Encode()
+}
 
 type EndTransactionRecord struct {
 }


### PR DESCRIPTION
This pull request adds the DescribeTopicPartition API, which includes the request encoder and decoder for DescribeTopicPartition, as well as the decoder for the DescribePartitionMetadata response. It also includes the necessary encoding methods for RecordBatch, Record, and RecordHeader. Additionally, it removes unused decoding logic and updates the .gitignore file.