### PR TITLE
CI: Investigate why CI tests are failing

### DIFF
--- a/internal/stagef2.go
+++ b/internal/stagef2.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -13,20 +14,20 @@ import (
 func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
 	if err := b.Run(); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	correlationId := getRandomCorrelationId()
 
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	defer broker.Close()
 
@@ -55,14 +56,14 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
 	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	if responseHeader.CorrelationId != correlationId {
@@ -81,4 +82,33 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	logger.Successf("✓ Topic responses: %v", responseBody.TopicResponses)
 
 	return nil
+}
+
+func listDirectoryContents(path string) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		fmt.Println("Error reading directory:", err)
+		return
+	}
+
+	for _, file := range files {
+		fmt.Println(file.Name())
+	}
+}
+
+func printFileContents(path string) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		return
+	}
+
+	fmt.Println(string(contents))
+}
+
+func wrapErrorAndDebug(err error) error {
+	fmt.Println(err.Error())
+	listDirectoryContents(".")
+	printFileContents("./kafka-output.log")
+	return err
 }

--- a/internal/stagef3.go
+++ b/internal/stagef3.go
@@ -14,13 +14,13 @@ import (
 func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
 	if err := b.Run(); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	correlationId := getRandomCorrelationId()
@@ -29,7 +29,7 @@ func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness)
 
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	defer broker.Close()
 
@@ -72,14 +72,14 @@ func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness)
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
 	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	if responseHeader.CorrelationId != correlationId {

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -15,20 +15,20 @@ import (
 func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
 	if err := b.Run(); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	correlationId := getRandomCorrelationId()
 
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	defer broker.Close()
 
@@ -71,14 +71,14 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
 	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
 	if err != nil {
-		return err
+		return wrapErrorAndDebug(err)
 	}
 
 	if responseHeader.CorrelationId != correlationId {

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -64,7 +64,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"name":                   {regexp.MustCompile(`- .name \([A-Za-z]{1,}\)`)},
 		"topic_name":             {regexp.MustCompile(`- .topic_name \([A-Za-z0-9 ]{1,}\)`)},
 		"next_cursor":            {regexp.MustCompile(`- .next_cursor \(\{[A-Za-z0-9 ]{1,}\}\)`)},
-		"MESSAGES":               {regexp.MustCompile(`✓ MESSAGES: \["[A-Za-z !]{1,}"\]`)},
+		"MESSAGES":               {regexp.MustCompile(`✓ Messages: \["[A-Za-z !]{1,}"\]`)},
 	}
 
 	for replacement, regexes := range replacements {

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -6,4 +6,5 @@
 # sudo chown -R user:group ./kafka-latest
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
-/usr/local/kafka-latest/bin/kafka-server-start.sh $@ > /dev/null 2>&1
+/usr/local/kafka-latest/bin/kafka-server-start.sh $@
+# > /dev/null 2>&1

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -6,4 +6,4 @@
 # sudo chown -R user:group ./kafka-latest
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
-/usr/local/kafka-latest/bin/kafka-server-start.sh $@ > /dev/null 2>&1
+/usr/local/kafka-latest/bin/kafka-server-start.sh $@ | sed 's/^/kafka-debug: /' >> kafka-output.log

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -6,5 +6,4 @@
 # sudo chown -R user:group ./kafka-latest
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
-/usr/local/kafka-latest/bin/kafka-server-start.sh $@
-# > /dev/null 2>&1
+/usr/local/kafka-latest/bin/kafka-server-start.sh $@ > /dev/null 2>&1


### PR DESCRIPTION
This pull request includes several changes to improve error handling and debugging in the Kafka tester, as well as a minor regex update and logging enhancement. The most important changes involve the introduction of a new error-wrapping function and additional utility functions for debugging purposes.

### Error Handling and Debugging Enhancements:
* Added `wrapErrorAndDebug` function to wrap errors with debugging information, including listing directory contents and printing file contents. (`internal/stagef2.go`)
* Replaced direct error returns with `wrapErrorAndDebug` in multiple test functions to provide better debugging information. (`internal/stagef2.go`, `internal/stagef3.go`, `internal/stagef4.go`) [[1]](diffhunk://#diff-e53a8c323a04c1e629745d5a6883150b2231aff4a460efc9fd8590600b34fbc4L16-R30) [[2]](diffhunk://#diff-fbb166d63bb0d8849fa68ecb71a6d5a528dc12ef585f9d902fcf5c161358aa20L17-R23) [[3]](diffhunk://#diff-a33e9a594f2d3e483df58b53b5af82ef22752865961ef7c1d3a730b71c512ca0L18-R31)

### Logging Improvements:
* Modified `your_program.sh` to prepend Kafka logs with a debug prefix and redirect output to `kafka-output.log`. (`internal/test_helpers/pass_all/your_program.sh`)

### Minor Update:
* Corrected the regex pattern for "MESSAGES" to "Messages" in `normalizeTesterOutput`. (`internal/stages_test.go`)