### PR TITLE
CI: Other test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,10 @@ jobs:
       - if: always()
         run: |
           # Find the latest file in /tmp/ directory that starts with "test-"
-          latest_file=$(ls -t /tmp/test-* | head -n1)
+          echo "Files in /tmp:"
+          ls -la /tmp | grep "test-"
+          echo ""
+          latest_file=$(ls /tmp/test-* | sort | tail -n1)
           echo "Latest file: $latest_file"
 
           # Check if a file was found

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
 
           # Check if a file was found
           if [ -n "$latest_file" ]; then
+              # Print the size of the file
+              echo "File size: $(du -h "$latest_file" | cut -f1)"
+              echo ""
+
               # Print the contents of the file
               cat "$latest_file"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,18 @@ jobs:
       - name: Run tests
         run: make test
 
+      - if: always()
+        run: |
+          # Find the latest file in /tmp/ directory that starts with "test-"
+          latest_file=$(ls -t /tmp/test-* | head -n1)
+          # Check if a file was found
+          if [ -n "$latest_file" ]; then
+              # Print the contents of the file
+              cat "$latest_file"
+          else
+              echo "No test file found in /tmp/ directory"
+          fi
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,13 @@ jobs:
               echo ""
 
               # Print the contents of the file
+              echo ""
+              echo "--- BASE64 ---"
+              echo ""
+              cat "$latest_file" | base64
+              echo ""
+              echo "--- RAW ---"
+              echo ""
               cat "$latest_file"
           else
               echo "No test file found in /tmp/ directory"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,18 +31,15 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Run tests 10 times and log failures
+      - name: Run tests up to 10 times and exit on first failure
         run: |
-          failures=0
           for i in {1..10}; do
             if ! make test; then
-              ((failures++))
+              echo "Test failed on attempt $i"
+              exit 1
             fi
           done
-          echo "Number of test failures: $failures"
-          if [ $failures -gt 0 ]; then
-            exit 1
-          fi
+          echo "All tests passed successfully"
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,15 @@
 name: Test
 
-on: push
+on: [push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Run tests 10 times and log failures
         run: |
@@ -41,6 +46,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           # Find the latest file in /tmp/ directory that starts with "test-"
           latest_file=$(ls -t /tmp/test-* | head -n1)
+          echo "Latest file: $latest_file"
+
           # Check if a file was found
           if [ -n "$latest_file" ]; then
               # Print the contents of the file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
 
       - if: always()
         run: |
-          # Find the latest file in /tmp/ directory that starts with "test-"
-          echo "Files in /tmp:"
-          ls -la /tmp | grep "test-"
+          # List files in /dev/shm directory that start with "test-"
+          echo "Files in /dev/shm:"
+          ls -la /dev/shm | grep "test-"
           echo ""
-          latest_file=$(ls /tmp/test-* | sort | tail -n1)
+          latest_file=$(ls /dev/shm/test-* | sort | tail -n1)
           echo "Latest file: $latest_file"
 
           # Check if a file was found
@@ -63,7 +63,7 @@ jobs:
               echo ""
               cat "$latest_file"
           else
-              echo "No test file found in /tmp/ directory"
+              echo "No test file found in /dev/shm directory"
           fi
 
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,19 @@ jobs:
         with:
           python-version: '3.9'
 
-      - run: make test
-  
+      - name: Run tests 10 times and log failures
+        run: |
+          failures=0
+          for i in {1..10}; do
+            if ! make test; then
+              ((failures++))
+            fi
+          done
+          echo "Number of test failures: $failures"
+          if [ $failures -gt 0 ]; then
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,15 +35,8 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Run tests up to 10 times and exit on first failure
-        run: |
-          for i in {1..10}; do
-            if ! make test; then
-              echo "Test failed on attempt $i"
-              exit 1
-            fi
-          done
-          echo "All tests passed successfully"
+      - name: Run tests
+        run: make test
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test_75_with_kafka: build
 	dist/main.out
 
 test:
-	TESTER_DIR=$(shell pwd) go test -v ./internal/ --count=1
+	TESTER_DIR=$(shell pwd) go test -v ./internal/ -failfast --count=1
 
 test_and_watch:
 	onchange '**/*' -- go test -v ./internal/

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -34,8 +34,8 @@ func TestStages(t *testing.T) {
 		// 	NormalizeOutputFunc: normalizeTesterOutput,
 		// },
 		"fetch_pass": {
-			// StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
-			StageSlugs:          []string{"dh6"}, // TODO: Does single trigger?
+			StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
+			// StageSlugs:          []string{"dh6"}, // TODO: Does single trigger?
 			CodePath:            "./test_helpers/pass_all",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/fetch/pass",

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -26,15 +26,15 @@ func TestStages(t *testing.T) {
 		// 	StdoutFixturePath:   "./test_helpers/fixtures/concurrent_stages/pass",
 		// 	NormalizeOutputFunc: normalizeTesterOutput,
 		// },
-		// "describe_topic_partitions_pass": {
-		// 	StageSlugs:          []string{"yk1", "vt6", "ea7", "ku4", "wq2"},
-		// 	CodePath:            "./test_helpers/pass_all",
-		// 	ExpectedExitCode:    0,
-		// 	StdoutFixturePath:   "./test_helpers/fixtures/describe_topic_partitions/pass",
-		// 	NormalizeOutputFunc: normalizeTesterOutput,
-		// },
+		"describe_topic_partitions_pass": {
+			StageSlugs:          []string{"yk1", "vt6", "ea7", "ku4", "wq2"},
+			CodePath:            "./test_helpers/pass_all",
+			ExpectedExitCode:    0,
+			StdoutFixturePath:   "./test_helpers/fixtures/describe_topic_partitions/pass",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"fetch_pass": {
-			StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
+			StageSlugs: []string{"gs0", "dh6", "hn6", "cm4"},
 			// StageSlugs:          []string{"dh6"}, // TODO: Does single trigger?
 			CodePath:            "./test_helpers/pass_all",
 			ExpectedExitCode:    0,

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"os"
-	"regexp"
+	// "regexp"
 	"testing"
 
 	tester_utils_testing "github.com/codecrafters-io/tester-utils/testing"
@@ -12,29 +12,30 @@ func TestStages(t *testing.T) {
 	os.Setenv("CODECRAFTERS_RANDOM_SEED", "1234567890")
 
 	testCases := map[string]tester_utils_testing.TesterOutputTestCase{
-		"base_stages_pass": {
-			UntilStageSlug:      "pv1",
-			CodePath:            "./test_helpers/pass_all",
-			ExpectedExitCode:    0,
-			StdoutFixturePath:   "./test_helpers/fixtures/base/pass",
-			NormalizeOutputFunc: normalizeTesterOutput,
-		},
-		"concurrent_stages_pass": {
-			StageSlugs:          []string{"nh4", "sk0"},
-			CodePath:            "./test_helpers/pass_all",
-			ExpectedExitCode:    0,
-			StdoutFixturePath:   "./test_helpers/fixtures/concurrent_stages/pass",
-			NormalizeOutputFunc: normalizeTesterOutput,
-		},
-		"describe_topic_partitions_pass": {
-			StageSlugs:          []string{"yk1", "vt6", "ea7", "ku4", "wq2"},
-			CodePath:            "./test_helpers/pass_all",
-			ExpectedExitCode:    0,
-			StdoutFixturePath:   "./test_helpers/fixtures/describe_topic_partitions/pass",
-			NormalizeOutputFunc: normalizeTesterOutput,
-		},
+		// "base_stages_pass": {
+		// 	UntilStageSlug:      "pv1",
+		// 	CodePath:            "./test_helpers/pass_all",
+		// 	ExpectedExitCode:    0,
+		// 	StdoutFixturePath:   "./test_helpers/fixtures/base/pass",
+		// 	NormalizeOutputFunc: normalizeTesterOutput,
+		// },
+		// "concurrent_stages_pass": {
+		// 	StageSlugs:          []string{"nh4", "sk0"},
+		// 	CodePath:            "./test_helpers/pass_all",
+		// 	ExpectedExitCode:    0,
+		// 	StdoutFixturePath:   "./test_helpers/fixtures/concurrent_stages/pass",
+		// 	NormalizeOutputFunc: normalizeTesterOutput,
+		// },
+		// "describe_topic_partitions_pass": {
+		// 	StageSlugs:          []string{"yk1", "vt6", "ea7", "ku4", "wq2"},
+		// 	CodePath:            "./test_helpers/pass_all",
+		// 	ExpectedExitCode:    0,
+		// 	StdoutFixturePath:   "./test_helpers/fixtures/describe_topic_partitions/pass",
+		// 	NormalizeOutputFunc: normalizeTesterOutput,
+		// },
 		"fetch_pass": {
-			StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
+			// StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
+			StageSlugs:          []string{"dh6"}, // TODO: Does single trigger?
 			CodePath:            "./test_helpers/pass_all",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/fetch/pass",
@@ -46,32 +47,33 @@ func TestStages(t *testing.T) {
 }
 
 func normalizeTesterOutput(testerOutput []byte) []byte {
-	replacements := map[string][]*regexp.Regexp{
-		"hexdump":                {regexp.MustCompile(`[0-9a-fA-F]{4} \| [0-9a-fA-F ]{47} \| .{0,16}`)},
-		"session_id":             {regexp.MustCompile(`- .session_id \([0-9]{0,16}\)`)},
-		"leader_id":              {regexp.MustCompile(`- .leader_id \([-0-9]{1,}\)`)},
-		"leader_epoch":           {regexp.MustCompile(`- .leader_epoch \([-0-9]{1,}\)`)},
-		"wrote_file":             {regexp.MustCompile(`- Wrote file to: .*`)},
-		"topic_id":               {regexp.MustCompile(`- .topic_id \([0-9]{8}-[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{12}\)`)},
-		"compact_records_length": {regexp.MustCompile(`- .compact_records_length \([0-9]{2,}\)`)},
-		"batch_length":           {regexp.MustCompile(`- .batch_length \([0-9]{2,}\)`)},
-		"crc":                    {regexp.MustCompile(`- .crc \([-0-9]{1,}\)`)},
-		"length":                 {regexp.MustCompile(`- .length \([0-9]{1,}\)`)},
-		"Name":                   {regexp.MustCompile(`✓ Topic Name: [0-9A-Za-z]{3}`)},
-		"UUID":                   {regexp.MustCompile(`✓ Topic UUID: [0-9]{8}-[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{12}`)},
-		"value_length":           {regexp.MustCompile(`- .value_length \([0-9]{1,}\)`)},
-		"value":                  {regexp.MustCompile(`- .value \("[A-Za-z0-9 !]{1,}"\)`)},
-		"name":                   {regexp.MustCompile(`- .name \([A-Za-z]{1,}\)`)},
-		"topic_name":             {regexp.MustCompile(`- .topic_name \([A-Za-z0-9 ]{1,}\)`)},
-		"next_cursor":            {regexp.MustCompile(`- .next_cursor \(\{[A-Za-z0-9 ]{1,}\}\)`)},
-		"MESSAGES":               {regexp.MustCompile(`✓ Messages: \["[A-Za-z !]{1,}"\]`)},
-	}
+	return []byte("empty")
+	// replacements := map[string][]*regexp.Regexp{
+	// 	"hexdump":                {regexp.MustCompile(`[0-9a-fA-F]{4} \| [0-9a-fA-F ]{47} \| .{0,16}`)},
+	// 	"session_id":             {regexp.MustCompile(`- .session_id \([0-9]{0,16}\)`)},
+	// 	"leader_id":              {regexp.MustCompile(`- .leader_id \([-0-9]{1,}\)`)},
+	// 	"leader_epoch":           {regexp.MustCompile(`- .leader_epoch \([-0-9]{1,}\)`)},
+	// 	"wrote_file":             {regexp.MustCompile(`- Wrote file to: .*`)},
+	// 	"topic_id":               {regexp.MustCompile(`- .topic_id \([0-9]{8}-[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{12}\)`)},
+	// 	"compact_records_length": {regexp.MustCompile(`- .compact_records_length \([0-9]{2,}\)`)},
+	// 	"batch_length":           {regexp.MustCompile(`- .batch_length \([0-9]{2,}\)`)},
+	// 	"crc":                    {regexp.MustCompile(`- .crc \([-0-9]{1,}\)`)},
+	// 	"length":                 {regexp.MustCompile(`- .length \([0-9]{1,}\)`)},
+	// 	"Name":                   {regexp.MustCompile(`✓ Topic Name: [0-9A-Za-z]{3}`)},
+	// 	"UUID":                   {regexp.MustCompile(`✓ Topic UUID: [0-9]{8}-[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{12}`)},
+	// 	"value_length":           {regexp.MustCompile(`- .value_length \([0-9]{1,}\)`)},
+	// 	"value":                  {regexp.MustCompile(`- .value \("[A-Za-z0-9 !]{1,}"\)`)},
+	// 	"name":                   {regexp.MustCompile(`- .name \([A-Za-z]{1,}\)`)},
+	// 	"topic_name":             {regexp.MustCompile(`- .topic_name \([A-Za-z0-9 ]{1,}\)`)},
+	// 	"next_cursor":            {regexp.MustCompile(`- .next_cursor \(\{[A-Za-z0-9 ]{1,}\}\)`)},
+	// 	"MESSAGES":               {regexp.MustCompile(`✓ Messages: \["[A-Za-z !]{1,}"\]`)},
+	// }
 
-	for replacement, regexes := range replacements {
-		for _, regex := range regexes {
-			testerOutput = regex.ReplaceAll(testerOutput, []byte(replacement))
-		}
-	}
+	// for replacement, regexes := range replacements {
+	// 	for _, regex := range regexes {
+	// 		testerOutput = regex.ReplaceAll(testerOutput, []byte(replacement))
+	// 	}
+	// }
 
-	return testerOutput
+	// return testerOutput
 }

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -12,20 +12,20 @@ func TestStages(t *testing.T) {
 	os.Setenv("CODECRAFTERS_RANDOM_SEED", "1234567890")
 
 	testCases := map[string]tester_utils_testing.TesterOutputTestCase{
-		// "base_stages_pass": {
-		// 	UntilStageSlug:      "pv1",
-		// 	CodePath:            "./test_helpers/pass_all",
-		// 	ExpectedExitCode:    0,
-		// 	StdoutFixturePath:   "./test_helpers/fixtures/base/pass",
-		// 	NormalizeOutputFunc: normalizeTesterOutput,
-		// },
-		// "concurrent_stages_pass": {
-		// 	StageSlugs:          []string{"nh4", "sk0"},
-		// 	CodePath:            "./test_helpers/pass_all",
-		// 	ExpectedExitCode:    0,
-		// 	StdoutFixturePath:   "./test_helpers/fixtures/concurrent_stages/pass",
-		// 	NormalizeOutputFunc: normalizeTesterOutput,
-		// },
+		"base_stages_pass": {
+			UntilStageSlug:      "pv1",
+			CodePath:            "./test_helpers/pass_all",
+			ExpectedExitCode:    0,
+			StdoutFixturePath:   "./test_helpers/fixtures/base/pass",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
+		"concurrent_stages_pass": {
+			StageSlugs:          []string{"nh4", "sk0"},
+			CodePath:            "./test_helpers/pass_all",
+			ExpectedExitCode:    0,
+			StdoutFixturePath:   "./test_helpers/fixtures/concurrent_stages/pass",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		"describe_topic_partitions_pass": {
 			StageSlugs:          []string{"yk1", "vt6", "ea7", "ku4", "wq2"},
 			CodePath:            "./test_helpers/pass_all",
@@ -34,8 +34,7 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"fetch_pass": {
-			StageSlugs: []string{"gs0", "dh6", "hn6", "cm4"},
-			// StageSlugs:          []string{"dh6"}, // TODO: Does single trigger?
+			StageSlugs:          []string{"gs0", "dh6", "hn6", "cm4"},
 			CodePath:            "./test_helpers/pass_all",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/fetch/pass",

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,4 +4,4 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-/usr/local/kafka-latest/bin/kafka-server-start.sh "$@"
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >/dev/null 2>&1

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -6,4 +6,6 @@
 # sudo chown -R user:group ./kafka-latest
 filePath="/tmp/test-$(date +%s%3N)"
 echo "FilePath: $filePath"
-/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >"$filePath" 2>&1
+echo "Started: $(date)" >"$filePath"
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >>"$filePath" 2>&1
+echo "Finished: $(date)" >>"$filePath"

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -5,8 +5,6 @@
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
 shmPath="/dev/shm/test-$(date +%s%3N)"
-echo "ShmPath: $shmPath"
-echo "Started: $(date)" >"$shmPath"
 
 if lsof -i :9092 >/dev/null 2>&1; then
     echo "bound"
@@ -15,6 +13,9 @@ else
     echo "not bound"
     echo "not bound" >>"$shmPath"
 fi
+
+echo "ShmPath: $shmPath"
+echo "Started: $(date)" >"$shmPath"
 
 # Trap EXIT signal to ensure cleanup
 trap 'cleanup' EXIT

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,4 +4,6 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >/dev/null 2>&1
+filePath="/tmp/test-$(date +%s%3N)"
+echo "FilePath: $filePath"
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >"$filePath" 2>&1

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,4 +4,4 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" > /dev/null 2>&1
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@"

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -8,6 +8,14 @@ shmPath="/dev/shm/test-$(date +%s%3N)"
 echo "ShmPath: $shmPath"
 echo "Started: $(date)" >"$shmPath"
 
+if lsof -i :9092 >/dev/null 2>&1; then
+    echo "bound"
+    echo "bound" >>"$shmPath"
+else
+    echo "not bound"
+    echo "not bound" >>"$shmPath"
+fi
+
 # Trap EXIT signal to ensure cleanup
 trap 'cleanup' EXIT
 

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,6 +4,4 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-SCRIPT_DIR=$(dirname "$(realpath "$0")")
-
 /usr/local/kafka-latest/bin/kafka-server-start.sh $@ > /dev/null

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,17 +4,18 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-filePath="/tmp/test-$(date +%s%3N)"
-echo "FilePath: $filePath"
-echo "Started: $(date)" >"$filePath"
+shmPath="/dev/shm/test-$(date +%s%3N)"
+echo "ShmPath: $shmPath"
+echo "Started: $(date)" >"$shmPath"
 
 # Trap EXIT signal to ensure cleanup
 trap 'cleanup' EXIT
 
 cleanup() {
     echo "Exit trapped"
-    echo "Cleanup finished: $(date)" >>"$filePath"
+    echo "Cleanup finished: $(date)" >>"$shmPath"
+    rm -f "$shmPath"
 }
 
-/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >>"$filePath" 2>&1
-echo "Finished: $(date)" >>"$filePath"
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >>"$shmPath" 2>&1
+echo "Finished: $(date)" >>"$shmPath"

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -7,5 +7,14 @@
 filePath="/tmp/test-$(date +%s%3N)"
 echo "FilePath: $filePath"
 echo "Started: $(date)" >"$filePath"
+
+# Trap EXIT signal to ensure cleanup
+trap 'cleanup' EXIT
+
+cleanup() {
+    echo "Exit trapped"
+    echo "Cleanup finished: $(date)" >>"$filePath"
+}
+
 /usr/local/kafka-latest/bin/kafka-server-start.sh "$@" >>"$filePath" 2>&1
 echo "Finished: $(date)" >>"$filePath"

--- a/internal/test_helpers/pass_all/your_program.sh
+++ b/internal/test_helpers/pass_all/your_program.sh
@@ -4,4 +4,4 @@
 # Get it from here: https://github.com/codecrafters-io/build-your-own-kafka/blob/main/kafka_2.13-4.0.0-SNAPSHOT.tgz
 # Extract it and make sure you update the permissions
 # sudo chown -R user:group ./kafka-latest
-/usr/local/kafka-latest/bin/kafka-server-start.sh $@ > /dev/null
+/usr/local/kafka-latest/bin/kafka-server-start.sh "$@" > /dev/null 2>&1

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -14,75 +14,92 @@ var testerDefinition = tester_definition.TesterDefinition{
 		{
 			Slug:     "vi6",
 			TestFunc: testBindToPort,
-			Timeout:  15 * time.Second,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "nv3",
 			TestFunc: testHardcodedCorrelationId,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "wa6",
 			TestFunc: testCorrelationId,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "nc5",
 			TestFunc: testAPIVersionErrorCase,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "pv1",
 			TestFunc: testAPIVersion,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "nh4",
 			TestFunc: testSequentialRequests,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "sk0",
 			TestFunc: testConcurrentRequests,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "gs0",
 			TestFunc: testAPIVersionwFetchKey,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "dh6",
 			TestFunc: testFetchWithNoTopics,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "hn6",
 			TestFunc: testFetchWithUnkownTopicID,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "cm4",
 			TestFunc: testFetch,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "eg2",
 			TestFunc: testSingleFetchFromDisk,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "fd8",
 			TestFunc: testMultiFetchFromDisk,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "yk1",
 			TestFunc: testAPIVersionwDescribeTopicPartitions,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "vt6",
 			TestFunc: testDTPartitionWithUnknownTopic,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "ea7",
 			TestFunc: testDTPartitionWithTopicAndSinglePartition,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "ku4",
 			TestFunc: testDTPartitionWithTopicAndMultiplePartitions2,
+			Timeout:  30 * time.Second,
 		},
 		{
 			Slug:     "wq2",
 			TestFunc: testDTPartitionWithTopics,
+			Timeout:  30 * time.Second,
 		},
 	},
 }

--- a/protocol/serializer/generate_log_dir.go
+++ b/protocol/serializer/generate_log_dir.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -127,6 +128,11 @@ func GenerateLogDirs(logger *logger.Logger) error {
 	err = writeKraftServerProperties(kraftServerPropertiesPath, logger)
 	if err != nil {
 		return err
+	}
+
+	cleanShutdownPath := filepath.Join(basePath, "clean_shutdown")
+	if err := os.WriteFile(cleanShutdownPath, []byte("{\"version\":0,\"brokerEpoch\":10}"), 0644); err != nil {
+		return fmt.Errorf("could not write clean shutdown file: %w", err)
 	}
 
 	logger.Infof("Finished writing log files to: %s", basePath)

--- a/protocol/serializer/generate_log_dir.go
+++ b/protocol/serializer/generate_log_dir.go
@@ -130,7 +130,7 @@ func GenerateLogDirs(logger *logger.Logger) error {
 		return err
 	}
 
-	cleanShutdownPath := filepath.Join(basePath, "clean_shutdown")
+	cleanShutdownPath := filepath.Join(basePath, ".kafka_cleanshutdown")
 	if err := os.WriteFile(cleanShutdownPath, []byte("{\"version\":0,\"brokerEpoch\":10}"), 0644); err != nil {
 		return fmt.Errorf("could not write clean shutdown file: %w", err)
 	}


### PR DESCRIPTION
- test
- Refactor tests by commenting out unused test cases and regex replacements.
- Update test workflow to run tests multiple times and log failures.
- Update GitHub Actions workflow with concurrency and timeout settings.
- Update test case to restore original StageSlugs for fetch_pass scenario.
- Update test workflow to exit on first failure instead of counting failures.
- Update Go setup action to version 5 in GitHub workflow configuration.
- Fix command execution in your_program.sh to redirect stderr to /dev/null.
- Restore commented-out test case for describe_topic_partitions_pass in tests.
- Remove output redirection from kafka-server-start.sh command in your_program.sh.
- Increase timeout for multiple test functions to 30 seconds in tester_definition.
- Add matrix strategy for test attempts in GitHub Actions workflow.
- Refactor test cases in stages_test.go to uncomment and organize structure.
- Add -failfast option to go test in Makefile for quicker test failures.
- Add clean shutdown file creation in GenerateLogDirs function
- Rename clean shutdown file to ".kafka_cleanshutdown" for clarity.
- Redirect kafka server output to /dev/null in your_program.sh script.
- Add logging for Kafka server start and output latest test file in CI workflow
- Add logging for the latest test file in GitHub Actions workflow
- Improve file listing and selection logic in GitHub Actions workflow script.
- Add file size logging in GitHub Actions and timestamp in Kafka server script.
- Add base64 and raw output for latest file in test workflow script
- Add cleanup function with EXIT trap to your_program.sh for better resource management.
- Update script to use shared memory path instead of temporary file path.
