### PR TITLE
Refactor DescribeTopicPartition to DescribeTopicPartitions

### DIFF
--- a/internal/assertions/describe_topic_assertion.go
+++ b/internal/assertions/describe_topic_assertion.go
@@ -1,0 +1,77 @@
+package assertions
+
+import (
+	"fmt"
+
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type DescribeTopicPartitionsResponseAssertion struct {
+	ActualValue   kafkaapi.DescribeTopicPartitionsResponse
+	ExpectedValue kafkaapi.DescribeTopicPartitionsResponse
+}
+
+func NewDescribeTopicPartitionsResponseAssertion(actualValue kafkaapi.DescribeTopicPartitionsResponse, expectedValue kafkaapi.DescribeTopicPartitionsResponse) DescribeTopicPartitionsResponseAssertion {
+	return DescribeTopicPartitionsResponseAssertion{ActualValue: actualValue, ExpectedValue: expectedValue}
+}
+
+func (a DescribeTopicPartitionsResponseAssertion) Evaluate(firstLevelFields, secondLevelFields, thirdLevelFields []string, logger *logger.Logger) error {
+	// firstLevelFields: ["ThrottleTimeMs"]
+	// secondLevelFields (Topics): ["Name", "TopicID", "Partitions"]
+	// thirdLevelFields (Partitions): ["ID", "Leader", "Replicas", "Isr"]
+
+	if Contains(firstLevelFields, "ThrottleTimeMs") {
+		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
+			return fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
+		}
+		logger.Successf("✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
+	}
+
+	if secondLevelFields != nil {
+		// If secondLevelFields is not nil, then we match the length of the topics array
+		if len(a.ActualValue.Topics) != len(secondLevelFields) {
+			return fmt.Errorf("Expected %s to have length %d, got %d", "TopicResponse", len(a.ExpectedValue.Topics), len(a.ActualValue.Topics))
+		}
+
+		// We will also assert each topic in the actual and expected arrays respectively
+		for i, actualTopic := range a.ActualValue.Topics {
+			expectedTopic := a.ExpectedValue.Topics[i]
+
+			if Contains(secondLevelFields, "ErrorCode") {
+				if actualTopic.ErrorCode != expectedTopic.ErrorCode {
+					return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("TopicResponse[%d] Error Code", i), expectedTopic.ErrorCode, actualTopic.ErrorCode)
+				}
+
+				errorCodeName, ok := errorCodes[int(actualTopic.ErrorCode)]
+				if !ok {
+					errorCodeName = "UNKNOWN"
+				}
+				logger.Successf("✓ TopicResponse[%d] Error code: %d (%s)", i, actualTopic.ErrorCode, errorCodeName)
+			}
+
+			if Contains(secondLevelFields, "Name") {
+				if actualTopic.Name != expectedTopic.Name {
+					return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Topic Name", i), expectedTopic.Name, actualTopic.Name)
+				}
+				logger.Successf("✓ TopicResponse[%d] Topic Name: %s", i, actualTopic.Name)
+			}
+
+			if Contains(secondLevelFields, "TopicID") {
+				if actualTopic.TopicID != expectedTopic.TopicID {
+					return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Topic UUID", i), expectedTopic.TopicID, actualTopic.TopicID)
+				}
+				logger.Successf("✓ TopicResponse[%d] Topic UUID: %s", i, actualTopic.TopicID)
+			}
+
+			if thirdLevelFields != nil {
+				// If thirdLevelFields is not nil, then we match the length of the partitions array
+				if len(actualTopic.Partitions) != len(expectedTopic.Partitions) {
+					return fmt.Errorf("Expected %s to have length %d, got %d", "PartitionResponse", len(expectedTopic.Partitions), len(actualTopic.Partitions))
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/assertions/describe_topic_assertion.go
+++ b/internal/assertions/describe_topic_assertion.go
@@ -10,10 +10,80 @@ import (
 type DescribeTopicPartitionsResponseAssertion struct {
 	ActualValue   kafkaapi.DescribeTopicPartitionsResponse
 	ExpectedValue kafkaapi.DescribeTopicPartitionsResponse
+	logger        *logger.Logger
+	err           error
 }
 
-func NewDescribeTopicPartitionsResponseAssertion(actualValue kafkaapi.DescribeTopicPartitionsResponse, expectedValue kafkaapi.DescribeTopicPartitionsResponse) DescribeTopicPartitionsResponseAssertion {
-	return DescribeTopicPartitionsResponseAssertion{ActualValue: actualValue, ExpectedValue: expectedValue}
+func NewDescribeTopicPartitionsResponseAssertion(actualValue kafkaapi.DescribeTopicPartitionsResponse, expectedValue kafkaapi.DescribeTopicPartitionsResponse, logger *logger.Logger) *DescribeTopicPartitionsResponseAssertion {
+	return &DescribeTopicPartitionsResponseAssertion{
+		ActualValue:   actualValue,
+		ExpectedValue: expectedValue,
+		logger:        logger,
+	}
+}
+
+func (a *DescribeTopicPartitionsResponseAssertion) AssertBody(fields []string) *DescribeTopicPartitionsResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+	if Contains(fields, "ThrottleTimeMs") {
+		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
+			return a
+		}
+		a.logger.Successf("✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
+	}
+
+	return a
+}
+
+func (a *DescribeTopicPartitionsResponseAssertion) AssertTopics(fields []string) *DescribeTopicPartitionsResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	if len(a.ActualValue.Topics) != len(a.ExpectedValue.Topics) {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.Topics), len(a.ActualValue.Topics))
+		return a
+	}
+
+	for i, actualTopic := range a.ActualValue.Topics {
+		expectedTopic := a.ExpectedValue.Topics[i]
+		if Contains(fields, "ErrorCode") {
+			if actualTopic.ErrorCode != expectedTopic.ErrorCode {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", "Error Code", expectedTopic.ErrorCode, actualTopic.ErrorCode)
+				return a
+			}
+			a.logger.Successf("✓ TopicResponse[%d] Error code: %d", i, actualTopic.ErrorCode)
+		}
+
+		if Contains(fields, "Name") {
+			if actualTopic.Name != expectedTopic.Name {
+				a.err = fmt.Errorf("Expected %s to be %s, got %s", "Topic Name", expectedTopic.Name, actualTopic.Name)
+				return a
+			}
+			a.logger.Successf("✓ TopicResponse[%d] Topic Name: %s", i, actualTopic.Name)
+		}
+
+		if Contains(fields, "TopicID") {
+			if actualTopic.TopicID != expectedTopic.TopicID {
+				a.err = fmt.Errorf("Expected %s to be %s, got %s", "Topic UUID", expectedTopic.TopicID, actualTopic.TopicID)
+				return a
+			}
+			a.logger.Successf("✓ TopicResponse[%d] Topic UUID: %s", i, actualTopic.TopicID)
+		}
+
+		if Contains(fields, "TopicAuthorizedOperations") {
+			if actualTopic.TopicAuthorizedOperations != expectedTopic.TopicAuthorizedOperations {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", "Topic Authorized Operations", expectedTopic.TopicAuthorizedOperations, actualTopic.TopicAuthorizedOperations)
+				return a
+			}
+			a.logger.Successf("✓ TopicResponse[%d] Topic Authorized Operations: %d", i, actualTopic.TopicAuthorizedOperations)
+		}
+	}
+
+	return a
+}
 }
 
 func (a DescribeTopicPartitionsResponseAssertion) Evaluate(firstLevelFields, secondLevelFields, thirdLevelFields []string, logger *logger.Logger) error {

--- a/internal/assertions/describe_topic_assertion.go
+++ b/internal/assertions/describe_topic_assertion.go
@@ -84,64 +84,50 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertTopics(fields []string)
 
 	return a
 }
+
+func (a *DescribeTopicPartitionsResponseAssertion) AssertPartitions(fields []string) *DescribeTopicPartitionsResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	for i, actualTopic := range a.ActualValue.Topics {
+		expectedTopic := a.ExpectedValue.Topics[i]
+		actualPartitions, expectedPartitions := actualTopic.Partitions, expectedTopic.Partitions
+
+		if len(actualPartitions) != len(expectedPartitions) {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
+			return a
+		}
+
+		for j, actualPartition := range actualPartitions {
+			expectedPartition := expectedPartitions[j]
+
+			if Contains(fields, "ErrorCode") {
+				if actualPartition.ErrorCode != expectedPartition.ErrorCode {
+					// ToDo: Improve error message
+					a.err = fmt.Errorf("Expected %s to be %d, got %d", "Error Code", expectedPartition.ErrorCode, actualPartition.ErrorCode)
+					return a
+				}
+				a.logger.Successf("✓ PartitionResponse[%d] Error code: %d", j, actualPartition.ErrorCode)
+			}
+
+			if Contains(fields, "PartitionIndex") {
+				if actualPartition.PartitionIndex != expectedPartition.PartitionIndex {
+					a.err = fmt.Errorf("Expected %s to be %d, got %d", "Partition Index", expectedPartition.PartitionIndex, actualPartition.PartitionIndex)
+					return a
+				}
+				a.logger.Successf("✓ PartitionResponse[%d] Partition Index: %d", j, actualPartition.PartitionIndex)
+			}
+
+		}
+	}
+
+	return a
 }
 
-func (a DescribeTopicPartitionsResponseAssertion) Evaluate(firstLevelFields, secondLevelFields, thirdLevelFields []string, logger *logger.Logger) error {
+func (a DescribeTopicPartitionsResponseAssertion) Run() error {
 	// firstLevelFields: ["ThrottleTimeMs"]
 	// secondLevelFields (Topics): ["Name", "TopicID", "Partitions"]
 	// thirdLevelFields (Partitions): ["ID", "Leader", "Replicas", "Isr"]
-
-	if Contains(firstLevelFields, "ThrottleTimeMs") {
-		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
-			return fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
-		}
-		logger.Successf("✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
-	}
-
-	if secondLevelFields != nil {
-		// If secondLevelFields is not nil, then we match the length of the topics array
-		if len(a.ActualValue.Topics) != len(secondLevelFields) {
-			return fmt.Errorf("Expected %s to have length %d, got %d", "TopicResponse", len(a.ExpectedValue.Topics), len(a.ActualValue.Topics))
-		}
-
-		// We will also assert each topic in the actual and expected arrays respectively
-		for i, actualTopic := range a.ActualValue.Topics {
-			expectedTopic := a.ExpectedValue.Topics[i]
-
-			if Contains(secondLevelFields, "ErrorCode") {
-				if actualTopic.ErrorCode != expectedTopic.ErrorCode {
-					return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("TopicResponse[%d] Error Code", i), expectedTopic.ErrorCode, actualTopic.ErrorCode)
-				}
-
-				errorCodeName, ok := errorCodes[int(actualTopic.ErrorCode)]
-				if !ok {
-					errorCodeName = "UNKNOWN"
-				}
-				logger.Successf("✓ TopicResponse[%d] Error code: %d (%s)", i, actualTopic.ErrorCode, errorCodeName)
-			}
-
-			if Contains(secondLevelFields, "Name") {
-				if actualTopic.Name != expectedTopic.Name {
-					return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Topic Name", i), expectedTopic.Name, actualTopic.Name)
-				}
-				logger.Successf("✓ TopicResponse[%d] Topic Name: %s", i, actualTopic.Name)
-			}
-
-			if Contains(secondLevelFields, "TopicID") {
-				if actualTopic.TopicID != expectedTopic.TopicID {
-					return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Topic UUID", i), expectedTopic.TopicID, actualTopic.TopicID)
-				}
-				logger.Successf("✓ TopicResponse[%d] Topic UUID: %s", i, actualTopic.TopicID)
-			}
-
-			if thirdLevelFields != nil {
-				// If thirdLevelFields is not nil, then we match the length of the partitions array
-				if len(actualTopic.Partitions) != len(expectedTopic.Partitions) {
-					return fmt.Errorf("Expected %s to have length %d, got %d", "PartitionResponse", len(expectedTopic.Partitions), len(actualTopic.Partitions))
-				}
-			}
-		}
-	}
-
-	return nil
+	return a.err
 }

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -32,14 +32,14 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}
 	defer broker.Close()
 
-	request := kafkaapi.DescribeTopicPartitionRequest{
+	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
 			ClientId:      "kafka-tester",
 		},
-		Body: kafkaapi.DescribeTopicPartitionRequestBody{
+		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{
 					Name: "unknown-topic",
@@ -49,17 +49,17 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionRequest(&request)
-	logger.Infof("Sending \"DescribeTopicPartition\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
+	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartition\" request: \n%v\n", GetFormattedHexdump(message))
-	logger.Debugf("Hexdump of received \"DescribeTopicPartition\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep3.go
+++ b/internal/stagep3.go
@@ -31,14 +31,14 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}
 	defer broker.Close()
 
-	request := kafkaapi.DescribeTopicPartitionRequest{
+	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
 			ClientId:      "kafka-tester",
 		},
-		Body: kafkaapi.DescribeTopicPartitionRequestBody{
+		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{
 					Name: common.TOPIC1_NAME,
@@ -48,17 +48,17 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionRequest(&request)
-	logger.Infof("Sending \"DescribeTopicPartition\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
+	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartition\" request: \n%v\n", GetFormattedHexdump(message))
-	logger.Debugf("Hexdump of received \"DescribeTopicPartition\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 
+	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
@@ -63,59 +64,55 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		return err
 	}
 
+	expectedDescribeTopicPartitionsResponse := kafkaapi.DescribeTopicPartitionsResponse{
+		ThrottleTimeMs: 0,
+		Topics: []kafkaapi.DescribeTopicPartitionsResponseTopic{
+			{
+				ErrorCode: 0,
+				Name:      common.TOPIC3_NAME,
+				TopicID:   common.TOPIC3_UUID,
+				Partitions: []kafkaapi.DescribeTopicPartitionsResponsePartition{
+					{
+						ErrorCode:              0,
+						PartitionIndex:         0,
+						LeaderID:               1,
+						LeaderEpoch:            1,
+						ReplicaNodes:           []int32{1},
+						IsrNodes:               []int32{1},
+						EligibleLeaderReplicas: []int32{1},
+						LastKnownELR:           []int32{1},
+						OfflineReplicas:        []int32{1},
+					},
+					{
+						ErrorCode:              0,
+						PartitionIndex:         1,
+						LeaderID:               1,
+						LeaderEpoch:            1,
+						ReplicaNodes:           []int32{1},
+						IsrNodes:               []int32{1},
+						EligibleLeaderReplicas: []int32{1},
+						LastKnownELR:           []int32{1},
+						OfflineReplicas:        []int32{1},
+					},
+				},
+			},
+		},
+	}
+
+	err = assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+		AssertBody([]string{"ThrottleTimeMs"}).
+		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}).
+		AssertPartitions([]string{"ErrorCode", "PartitionIndex"}).
+		Run()
+
+	if err != nil {
+		return err
+	}
+
 	if responseHeader.CorrelationId != correlationId {
 		return fmt.Errorf("Expected Correlation ID to be %v, got %v", correlationId, responseHeader.CorrelationId)
 	}
 	logger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
-
-	if len(responseBody.Topics) != 1 {
-		return fmt.Errorf("Expected topics.length to be 2, got %v", len(responseBody.Topics))
-	}
-
-	topicResponse := responseBody.Topics[0]
-
-	if topicResponse.ErrorCode != 0 {
-		return fmt.Errorf("Expected Error code to be 0, got %v", topicResponse.ErrorCode)
-	}
-	logger.Successf("✓ TopicResponse Error code: 0")
-
-	if topicResponse.Name != common.TOPIC3_NAME {
-		return fmt.Errorf("Expected Topic to be %v, got %v", common.TOPIC3_NAME, topicResponse.Name)
-	}
-	logger.Successf("✓ Topic Name: %v", topicResponse.Name)
-
-	if topicResponse.TopicID != common.TOPIC3_UUID {
-		return fmt.Errorf("Expected Topic ID to be %v, got %v", common.TOPIC3_UUID, topicResponse.TopicID)
-	}
-	logger.Successf("✓ Topic UUID: %v", topicResponse.TopicID)
-
-	if len(topicResponse.Partitions) != 2 {
-		return fmt.Errorf("Expected Partitions to have length 2, got %v", len(topicResponse.Partitions))
-	}
-
-	partitionResponse1 := topicResponse.Partitions[0]
-
-	if partitionResponse1.ErrorCode != 0 {
-		return fmt.Errorf("Expected Error code to be 0, got %v", partitionResponse1.ErrorCode)
-	}
-	logger.Successf("✓ PartitionResponse[0] Error code: 0")
-
-	if partitionResponse1.PartitionIndex != 0 {
-		return fmt.Errorf("Expected Partition Index to be 0, got %v", partitionResponse1.PartitionIndex)
-	}
-	logger.Successf("✓ PartitionResponse[0] Partition Index: 0")
-
-	partitionResponse2 := topicResponse.Partitions[1]
-
-	if partitionResponse2.ErrorCode != 0 {
-		return fmt.Errorf("Expected Error code to be 0, got %v", partitionResponse2.ErrorCode)
-	}
-	logger.Successf("✓ PartitionResponse[1] Error code: 0")
-
-	if partitionResponse2.PartitionIndex != 1 {
-		return fmt.Errorf("Expected Partition Index to be 1, got %v", partitionResponse2.PartitionIndex)
-	}
-	logger.Successf("✓ PartitionResponse[1] Partition Index: 1")
 
 	return nil
 }

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"fmt"
-
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -64,6 +62,13 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		return err
 	}
 
+	expectedResponseHeader := kafkaapi.ResponseHeader{
+		CorrelationId: correlationId,
+	}
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+		return err
+	}
+
 	expectedDescribeTopicPartitionsResponse := kafkaapi.DescribeTopicPartitionsResponse{
 		ThrottleTimeMs: 0,
 		Topics: []kafkaapi.DescribeTopicPartitionsResponseTopic{
@@ -105,14 +110,5 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		AssertPartitions([]string{"ErrorCode", "PartitionIndex"}).
 		Run()
 
-	if err != nil {
-		return err
-	}
-
-	if responseHeader.CorrelationId != correlationId {
-		return fmt.Errorf("Expected Correlation ID to be %v, got %v", correlationId, responseHeader.CorrelationId)
-	}
-	logger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
-
-	return nil
+	return err
 }

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -30,14 +30,14 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}
 	defer broker.Close()
 
-	request := kafkaapi.DescribeTopicPartitionRequest{
+	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
 			ClientId:      "kafka-tester",
 		},
-		Body: kafkaapi.DescribeTopicPartitionRequestBody{
+		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{
 					Name: common.TOPIC3_NAME,
@@ -47,17 +47,17 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionRequest(&request)
-	logger.Infof("Sending \"DescribeTopicPartition\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
+	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartition\" request: \n%v\n", GetFormattedHexdump(message))
-	logger.Debugf("Hexdump of received \"DescribeTopicPartition\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep6.go
+++ b/internal/stagep6.go
@@ -27,14 +27,14 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 	defer broker.Close()
 
-	request := kafkaapi.DescribeTopicPartitionRequest{
+	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
 			ClientId:      "kafka-tester",
 		},
-		Body: kafkaapi.DescribeTopicPartitionRequestBody{
+		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{
 					Name: common.TOPIC1_NAME,
@@ -52,18 +52,17 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	message := kafkaapi.EncodeDescribeTopicPartitionRequest(&request)
-	// ToDo: DescribeTopicPartitions
-	logger.Infof("Sending \"DescribeTopicPartition\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
+	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartition\" request: \n%v\n", GetFormattedHexdump(message))
-	logger.Debugf("Hexdump of received \"DescribeTopicPartition\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
 	if err != nil {
 		return err
 	}

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -4,23 +4,23 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
-type DescribeTopicPartitionRequest struct {
+type DescribeTopicPartitionsRequest struct {
 	Header RequestHeader
-	Body   DescribeTopicPartitionRequestBody
+	Body   DescribeTopicPartitionsRequestBody
 }
 
-func (r *DescribeTopicPartitionRequest) Encode(pe *encoder.RealEncoder) {
+func (r *DescribeTopicPartitionsRequest) Encode(pe *encoder.RealEncoder) {
 	r.Header.EncodeV2(pe)
 	r.Body.Encode(pe)
 }
 
-type DescribeTopicPartitionRequestBody struct {
+type DescribeTopicPartitionsRequestBody struct {
 	Topics                 []TopicName
 	ResponsePartitionLimit int32
 	Cursor                 Cursor
 }
 
-func (r *DescribeTopicPartitionRequestBody) Encode(pe *encoder.RealEncoder) {
+func (r *DescribeTopicPartitionsRequestBody) Encode(pe *encoder.RealEncoder) {
 	// Encode topics array length
 	pe.PutCompactArrayLength(len(r.Topics))
 


### PR DESCRIPTION
This pull request refactors the code to replace the usage of the `DescribeTopicPartition` struct and related methods with the `DescribeTopicPartitions` struct and methods. This change ensures consistency in naming and improves code readability.