### PR TITLE
Refactor error handling in test functions and update describeTopicPartitionsResponseAssertion fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,7 @@ dist/
 # misc files
 protocol/decoder/error-codes.md
 main.go
-internal/metadata.go
-internal/stage3_test.go
-internal/stage2_test.go
-protocol/decoder/todo
 **/__pycache__/**
 internal/test_helpers/ryan/**
 internal/assertion.go
-log
-log2
-**tmp**
-file
+internal/assertions/topic_assertion.go

--- a/internal/assertions/describe_topic_partitions_response_assertion.go
+++ b/internal/assertions/describe_topic_partitions_response_assertion.go
@@ -130,7 +130,7 @@ func (a *DescribeTopicPartitionsResponseAssertion) assertPartitions(expectedPart
 
 func (a DescribeTopicPartitionsResponseAssertion) Run() error {
 	// firstLevelFields: ["ThrottleTimeMs"]
-	// secondLevelFields (Topics): ["Name", "TopicID", "Partitions"]
-	// thirdLevelFields (Partitions): ["ID", "Leader", "Replicas", "Isr"]
+	// secondLevelFields (Topics): ["ErrorCode", "Name", "TopicID", "TopicAuthorizedOperations"]
+	// thirdLevelFields (Partitions): ["ErrorCode, "PartitionIndex"]
 	return a.err
 }

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -83,10 +83,8 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	err = assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
 		Run()
-
-	return err
 }

--- a/internal/stagep3.go
+++ b/internal/stagep3.go
@@ -92,10 +92,8 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	err = assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
 		Run()
-
-	return err
 }

--- a/internal/stagep4.go
+++ b/internal/stagep4.go
@@ -104,10 +104,8 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	err = assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{"ErrorCode", "PartitionIndex"}).
 		Run()
-
-	return err
 }

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -145,10 +145,8 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	err = assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{"ErrorCode", "PartitionIndex"}).
 		Run()
-
-	return err
 }


### PR DESCRIPTION
Refactor the test functions to directly return the result of assertion runs, removing unnecessary intermediate error variables. Also, update the fields in the describeTopicPartitionsResponseAssertion struct to match the latest changes in the code.