### PR TITLE
Refactor fetch response assertions and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test_current:
 	make test_base_with_kafka
 	make test_concurrent_requests_with_kafka
 	make test_describe_topic_partitions_with_kafka
-	make test_fetch_partial_with_kafka
+	make test_fetch_with_kafka
 
 test_fetch_with_kafka: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ test_concurrent_requests_with_kafka: build
 	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"nh4\",\"tester_log_prefix\":\"stage-C1\",\"title\":\"Stage #C1: Multiple sequential requests from client\"}, {\"slug\":\"sk0\",\"tester_log_prefix\":\"stage-C2\",\"title\":\"Stage #C2: Multiple concurrent requests from client\"}]" \
 	dist/main.out
 
-test_fetch_partial_with_kafka: build
-	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
-	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"gs0\",\"tester_log_prefix\":\"stage-F1\",\"title\":\"Stage #F1: API Version with Fetch Key\"}, {\"slug\":\"dh6\",\"tester_log_prefix\":\"stage-F2\",\"title\":\"Stage #F2: Empty Fetch\"}, {\"slug\":\"hn6\",\"tester_log_prefix\":\"stage-F3\",\"title\":\"Stage #F3: Fetch with Empty Topic\"}, {\"slug\":\"cm4\",\"tester_log_prefix\":\"stage-F4\",\"title\":\"Stage #F4: Fetch Error Response\"}]" \
-	dist/main.out
 
 test_current:
 	make test_base_with_kafka
@@ -38,12 +34,12 @@ test_current:
 
 test_fetch_with_kafka: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
-	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"gs0\",\"tester_log_prefix\":\"stage-F1\",\"title\":\"Stage #F1: API Version with Fetch Key\"}, {\"slug\":\"dh6\",\"tester_log_prefix\":\"stage-F2\",\"title\":\"Stage #F2: Empty Fetch\"}, {\"slug\":\"hn6\",\"tester_log_prefix\":\"stage-F3\",\"title\":\"Stage #F3: Fetch with Empty Topic\"}, {\"slug\":\"cm4\",\"tester_log_prefix\":\"stage-F4\",\"title\":\"Stage #F4: Fetch Error Response\"}, {\"slug\":\"eg2\",\"tester_log_prefix\":\"stage-F5\",\"title\":\"Stage #F5: Single Fetch from Disk\"}, {\"slug\":\"fd8\",\"tester_log_prefix\":\"stage-F6\",\"title\":\"Stage #F6: Multi Fetch from Disk\"}]" \
+	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"gs0\",\"tester_log_prefix\":\"stage-F1\",\"title\":\"Stage #F1: API Version with Fetch Key\"}, {\"slug\":\"dh6\",\"tester_log_prefix\":\"stage-F2\",\"title\":\"Stage #F2: Fetch with no topics\"}, {\"slug\":\"hn6\",\"tester_log_prefix\":\"stage-F3\",\"title\":\"Stage #F3: Fetch with unknown topic\"}, {\"slug\":\"cm4\",\"tester_log_prefix\":\"stage-F4\",\"title\":\"Stage #F4: Fetch with empty topic\"}, {\"slug\":\"eg2\",\"tester_log_prefix\":\"stage-F5\",\"title\":\"Stage #F5: Single Fetch from Disk\"}, {\"slug\":\"fd8\",\"tester_log_prefix\":\"stage-F6\",\"title\":\"Stage #F6: Multi Fetch from Disk\"}]" \
 	dist/main.out
 
 test_75_with_kafka: build
 	CODECRAFTERS_REPOSITORY_DIR=./internal/test_helpers/pass_all \
-	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"xy6\",\"tester_log_prefix\":\"stage-P6\",\"title\":\"Stage #P6: Describe Topic Partitions 2\"}]" \
+	CODECRAFTERS_TEST_CASES_JSON="[{\"slug\":\"fd8\",\"tester_log_prefix\":\"stage-F6\",\"title\":\"Stage #F6: Multi Fetch from Disk\"}]" \
 	dist/main.out
 
 test:

--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -23,7 +23,8 @@ var apiKeyNames = map[int16]string{
 }
 
 var errorCodes = map[int]string{
-	0: "NO_ERROR",
+	0:   "NO_ERROR",
+	100: "UNKNOWN_TOPIC_ID",
 }
 
 func (a ApiVersionsResponseAssertion) Evaluate(fields []string, AssertApiVersionsResponseKey bool, logger *logger.Logger) error {

--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -24,6 +24,8 @@ var apiKeyNames = map[int16]string{
 
 var errorCodes = map[int]string{
 	0:   "NO_ERROR",
+	3:   "UNKNOWN_TOPIC_OR_PARTITION",
+	35:  "UNSUPPORTED_VERSION",
 	100: "UNKNOWN_TOPIC_ID",
 }
 

--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -41,7 +41,12 @@ func (a *FetchResponseAssertion) AssertBody(fields []string) *FetchResponseAsser
 			a.err = fmt.Errorf("Expected %s to be %d, got %d", "ErrorCode", a.ExpectedValue.ErrorCode, a.ActualValue.ErrorCode)
 			return a
 		}
-		a.logger.Successf("✓ Error Code: %d", a.ActualValue.ErrorCode)
+
+		errorCodeName, ok := errorCodes[int(a.ActualValue.ErrorCode)]
+		if !ok {
+			errorCodeName = "UNKNOWN"
+		}
+		a.logger.Successf("✓ Error Code: %d (%s)", a.ActualValue.ErrorCode, errorCodeName)
 	}
 
 	if Contains(fields, "SessionID") {
@@ -105,7 +110,13 @@ func (a *FetchResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.
 				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
 				return a
 			}
-			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d", j, actualPartition.ErrorCode)
+
+			errorCodeName, ok := errorCodes[int(a.ActualValue.ErrorCode)]
+			if !ok {
+				errorCodeName = "UNKNOWN"
+			}
+
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
 		}
 
 		if Contains(fields, "PartitionIndex") {

--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -1,0 +1,128 @@
+package assertions
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/kafka-tester/protocol"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type FetchResponseAssertion struct {
+	ActualValue   kafkaapi.FetchResponse
+	ExpectedValue kafkaapi.FetchResponse
+	logger        *logger.Logger
+	err           error
+}
+
+func NewFetchResponseAssertion(actualValue kafkaapi.FetchResponse, expectedValue kafkaapi.FetchResponse, logger *logger.Logger) *FetchResponseAssertion {
+	return &FetchResponseAssertion{
+		ActualValue:   actualValue,
+		ExpectedValue: expectedValue,
+		logger:        logger,
+	}
+}
+
+func (a *FetchResponseAssertion) AssertBody(fields []string) *FetchResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+	if Contains(fields, "ThrottleTimeMs") {
+		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
+			return a
+		}
+		a.logger.Successf("✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
+	}
+
+	if Contains(fields, "ErrorCode") {
+		if a.ActualValue.ErrorCode != a.ExpectedValue.ErrorCode {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "ErrorCode", a.ExpectedValue.ErrorCode, a.ActualValue.ErrorCode)
+			return a
+		}
+		a.logger.Successf("✓ Error Code: %d", a.ActualValue.ErrorCode)
+	}
+
+	if Contains(fields, "SessionID") {
+		if a.ActualValue.SessionID != a.ExpectedValue.SessionID {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "SessionID", a.ExpectedValue.SessionID, a.ActualValue.SessionID)
+			return a
+		}
+		a.logger.Successf("✓ Session ID: %d", a.ActualValue.SessionID)
+	}
+
+	return a
+}
+
+func (a *FetchResponseAssertion) AssertTopics(topicFields []string, partitionFields []string, recordBatchFields []string, recordFields []string) *FetchResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	if len(a.ActualValue.TopicResponses) != len(a.ExpectedValue.TopicResponses) {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.TopicResponses), len(a.ActualValue.TopicResponses))
+		return a
+	}
+
+	for i, actualTopic := range a.ActualValue.TopicResponses {
+		expectedTopic := a.ExpectedValue.TopicResponses[i]
+		if Contains(topicFields, "Topic") {
+			if actualTopic.Topic != expectedTopic.Topic {
+				a.err = fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Topic UUID", i), expectedTopic.Topic, actualTopic.Topic)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 1, "✓ TopicResponse[%d] Topic UUID: %s", i, actualTopic.Topic)
+		}
+
+		expectedPartitions := expectedTopic.PartitionResponses
+		actualPartitions := actualTopic.PartitionResponses
+
+		if (partitionFields) != nil {
+			a.assertPartitions(expectedPartitions, actualPartitions, partitionFields)
+		} else {
+			if len(actualPartitions) != 0 {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", 0, len(actualPartitions))
+				return a
+			}
+		}
+	}
+
+	return a
+}
+
+func (a *FetchResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.PartitionResponse, actualPartitions []kafkaapi.PartitionResponse, fields []string) *FetchResponseAssertion {
+	if len(actualPartitions) != len(expectedPartitions) {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
+		return a
+	}
+
+	for j, actualPartition := range actualPartitions {
+		expectedPartition := expectedPartitions[j]
+
+		if Contains(fields, "ErrorCode") {
+			if actualPartition.ErrorCode != expectedPartition.ErrorCode {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d", j, actualPartition.ErrorCode)
+		}
+
+		if Contains(fields, "PartitionIndex") {
+			if actualPartition.PartitionIndex != expectedPartition.PartitionIndex {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Partition Index", j), expectedPartition.PartitionIndex, actualPartition.PartitionIndex)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Partition Index: %d", j, actualPartition.PartitionIndex)
+		}
+
+	}
+
+	return a
+}
+
+func (a FetchResponseAssertion) Run() error {
+	// firstLevelFields: ["ThrottleTimeMs", "ErrorCode", "SessionID"]
+	// secondLevelFields (Topics): ["ErrorCode", "Name", "TopicID", "TopicAuthorizedOperations"]
+	// thirdLevelFields (Partitions): ["ErrorCode, "PartitionIndex"]
+	return a.err
+}

--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -125,7 +125,7 @@ func (a *FetchResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.
 				return a
 			}
 
-			errorCodeName, ok := errorCodes[int(a.ActualValue.ErrorCode)]
+			errorCodeName, ok := errorCodes[int(actualPartition.ErrorCode)]
 			if !ok {
 				errorCodeName = "UNKNOWN"
 			}

--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -60,6 +60,20 @@ func (a *FetchResponseAssertion) AssertBody(fields []string) *FetchResponseAsser
 	return a
 }
 
+func (a *FetchResponseAssertion) AssertNoTopics() *FetchResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	if len(a.ActualValue.TopicResponses) != 0 {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "topics.length", 0, len(a.ActualValue.TopicResponses))
+		return a
+	}
+	protocol.SuccessLogWithIndentation(a.logger, 1, "✓ TopicResponses: %v", a.ActualValue.TopicResponses)
+
+	return a
+}
+
 func (a *FetchResponseAssertion) AssertTopics(topicFields []string, partitionFields []string, recordBatchFields []string, recordFields []string) *FetchResponseAssertion {
 	if a.err != nil {
 		return a
@@ -137,6 +151,7 @@ func (a *FetchResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.
 				a.err = fmt.Errorf("Expected %s to be %d, got %d", "recordBatches.length", 0, len(actualRecordBatches))
 				return a
 			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ RecordBatches: %v", actualPartition.RecordBatches)
 		}
 	}
 

--- a/internal/stagef2.go
+++ b/internal/stagef2.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"fmt"
-
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -73,15 +71,13 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	if responseBody.ErrorCode != 0 {
-		return fmt.Errorf("Expected Error code to be 0, got %v", responseBody.ErrorCode)
+	expectedFetchResponse := kafkaapi.FetchResponse{
+		ThrottleTimeMs: 0,
+		ErrorCode:      0,
+		SessionID:      0,
+		TopicResponses: []kafkaapi.TopicResponse{},
 	}
-	logger.Successf("✓ Error code: 0 (NO_ERROR)")
-
-	if len(responseBody.TopicResponses) != 0 {
-		return fmt.Errorf("Expected responses to be empty, got %v", responseBody.TopicResponses)
-	}
-	logger.Successf("✓ Topic responses: %v", responseBody.TopicResponses)
-
-	return nil
+	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
+		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
+		Run()
 }

--- a/internal/stagef2.go
+++ b/internal/stagef2.go
@@ -79,5 +79,6 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	}
 	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
+		AssertNoTopics().
 		Run()
 }

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -10,7 +10,7 @@ import (
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
-func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
+func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
 	if err := b.Run(); err != nil {
 		return err
@@ -46,7 +46,7 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 			FetchSessionEpoch: 0,
 			Topics: []kafkaapi.Topic{
 				{
-					TopicUUID: common.TOPIC1_UUID,
+					TopicUUID: common.TOPIC2_UUID,
 					Partitions: []kafkaapi.Partition{
 						{
 							ID:                 0,
@@ -92,7 +92,7 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 		SessionID:      0,
 		TopicResponses: []kafkaapi.TopicResponse{
 			{
-				Topic: common.TOPIC1_UUID,
+				Topic: common.TOPIC2_UUID,
 				PartitionResponses: []kafkaapi.PartitionResponse{
 					{
 						PartitionIndex:      0,
@@ -101,32 +101,7 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 						LastStableOffset:    0,
 						LogStartOffset:      0,
 						AbortedTransactions: []kafkaapi.AbortedTransaction{},
-						RecordBatches: []kafkaapi.RecordBatch{
-							{
-								BaseOffset:           0,
-								BatchLength:          0,
-								PartitionLeaderEpoch: 0,
-								Magic:                0,
-								Attributes:           0,
-								LastOffsetDelta:      0,
-								FirstTimestamp:       0,
-								MaxTimestamp:         0,
-								ProducerId:           0,
-								ProducerEpoch:        0,
-								BaseSequence:         0,
-								Records: []kafkaapi.Record{
-									{
-										Length:         0,
-										Attributes:     0,
-										TimestampDelta: 0,
-										OffsetDelta:    0,
-										Key:            []byte{},
-										Value:          []byte(common.MESSAGE1),
-										Headers:        []kafkaapi.RecordHeader{},
-									},
-								},
-							},
-						},
+						RecordBatches:       []kafkaapi.RecordBatch{},
 						PreferedReadReplica: 0,
 					},
 				},
@@ -136,6 +111,6 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
-		AssertTopics([]string{"Topic"}, []string{"ErrorCode", "PartitionIndex"}, []string{"BaseOffset"}, []string{"Value"}).
+		AssertTopics([]string{"Topic"}, []string{"ErrorCode", "PartitionIndex"}, nil, nil).
 		Run()
 }

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -1,9 +1,6 @@
 package internal
 
 import (
-	"fmt"
-	"reflect"
-
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -137,46 +134,8 @@ func testFetch(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	err = assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
+	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
 		AssertTopics([]string{"Topic"}, []string{"ErrorCode", "PartitionIndex"}, []string{"BaseOffset"}, []string{"Value"}).
 		Run()
-
-	if err != nil {
-		return err
-	}
-
-	if responseBody.ErrorCode != 0 {
-		return fmt.Errorf("Expected Error code to be 0, got %v", responseBody.ErrorCode)
-	}
-	logger.Successf("✓ Error code: 0 (NO_ERROR)")
-
-	msgValues := []string{}
-	expectedMsgValues := []string{common.MESSAGE1}
-	for _, topicResponse := range responseBody.TopicResponses {
-		for _, partitionResponse := range topicResponse.PartitionResponses {
-			if len(partitionResponse.RecordBatches) == 0 {
-				return fmt.Errorf("Expected partition.RecordBatches to have length greater than 0, got %v", len(partitionResponse.RecordBatches))
-			}
-			for _, recordBatch := range partitionResponse.RecordBatches {
-				if len(recordBatch.Records) == 0 {
-					return fmt.Errorf("Expected recordBatch.Records to have length greater than 0, got %v", len(recordBatch.Records))
-				}
-				for _, r := range recordBatch.Records {
-					if r.Value == nil {
-						return fmt.Errorf("Expected record.Value to not be nil")
-					}
-					msgValues = append(msgValues, string(r.Value))
-				}
-			}
-		}
-	}
-
-	if !reflect.DeepEqual(msgValues, expectedMsgValues) {
-		return fmt.Errorf("Expected message values to be %v, got %v", expectedMsgValues, msgValues)
-	}
-
-	logger.Successf("✓ Messages: %q", msgValues)
-
-	return nil
 }

--- a/internal/stagef5.go
+++ b/internal/stagef5.go
@@ -1,11 +1,141 @@
 package internal
 
 import (
-	"fmt"
-
+	"github.com/codecrafters-io/kafka-tester/internal/assertions"
+	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	"github.com/codecrafters-io/kafka-tester/protocol"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
-func testSingleFetchFromDisk(stageHarness *test_case_harness.TestCaseHarness) error {
-	return fmt.Errorf("This stage is not implemented yet, we are working on it!")
+func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := kafka_executable.NewKafkaExecutable(stageHarness)
+	if err := b.Run(); err != nil {
+		return err
+	}
+
+	logger := stageHarness.Logger
+	err := serializer.GenerateLogDirs(logger)
+	if err != nil {
+		return err
+	}
+
+	correlationId := getRandomCorrelationId()
+
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, logger); err != nil {
+		return err
+	}
+	defer broker.Close()
+
+	request := kafkaapi.FetchRequest{
+		Header: kafkaapi.RequestHeader{
+			ApiKey:        1,
+			ApiVersion:    16,
+			CorrelationId: correlationId,
+			ClientId:      "kafka-cli",
+		},
+		Body: kafkaapi.FetchRequestBody{
+			MaxWaitMS:         500,
+			MinBytes:          1,
+			MaxBytes:          52428800,
+			IsolationLevel:    0,
+			FetchSessionID:    0,
+			FetchSessionEpoch: 0,
+			Topics: []kafkaapi.Topic{
+				{
+					TopicUUID: common.TOPIC1_UUID,
+					Partitions: []kafkaapi.Partition{
+						{
+							ID:                 0,
+							CurrentLeaderEpoch: -1,
+							FetchOffset:        0,
+							LastFetchedOffset:  -1,
+							LogStartOffset:     -1,
+							PartitionMaxBytes:  1048576,
+						},
+					},
+				},
+			},
+			ForgottenTopics: []kafkaapi.ForgottenTopic{},
+			RackID:          "",
+		},
+	}
+
+	message := kafkaapi.EncodeFetchRequest(&request)
+	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+
+	response, err := broker.SendAndReceive(message)
+	if err != nil {
+		return err
+	}
+	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	if err != nil {
+		return err
+	}
+
+	expectedResponseHeader := kafkaapi.ResponseHeader{
+		CorrelationId: correlationId,
+	}
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+		return err
+	}
+
+	expectedFetchResponse := kafkaapi.FetchResponse{
+		ThrottleTimeMs: 0,
+		ErrorCode:      0,
+		SessionID:      0,
+		TopicResponses: []kafkaapi.TopicResponse{
+			{
+				Topic: common.TOPIC1_UUID,
+				PartitionResponses: []kafkaapi.PartitionResponse{
+					{
+						PartitionIndex:      0,
+						ErrorCode:           0,
+						HighWatermark:       0,
+						LastStableOffset:    0,
+						LogStartOffset:      0,
+						AbortedTransactions: []kafkaapi.AbortedTransaction{},
+						RecordBatches: []kafkaapi.RecordBatch{
+							{
+								BaseOffset:           0,
+								BatchLength:          0,
+								PartitionLeaderEpoch: 0,
+								Magic:                0,
+								Attributes:           0,
+								LastOffsetDelta:      0,
+								FirstTimestamp:       0,
+								MaxTimestamp:         0,
+								ProducerId:           0,
+								ProducerEpoch:        0,
+								BaseSequence:         0,
+								Records: []kafkaapi.Record{
+									{
+										Length:         0,
+										Attributes:     0,
+										TimestampDelta: 0,
+										OffsetDelta:    0,
+										Key:            []byte{},
+										Value:          []byte(common.MESSAGE1),
+										Headers:        []kafkaapi.RecordHeader{},
+									},
+								},
+							},
+						},
+						PreferedReadReplica: 0,
+					},
+				},
+			},
+		},
+	}
+
+	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
+		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
+		AssertTopics([]string{"Topic"}, []string{"ErrorCode", "PartitionIndex"}, []string{"BaseOffset"}, []string{"Value"}).
+		Run()
 }

--- a/internal/stagef6.go
+++ b/internal/stagef6.go
@@ -1,11 +1,165 @@
 package internal
 
 import (
-	"fmt"
-
+	"github.com/codecrafters-io/kafka-tester/internal/assertions"
+	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	"github.com/codecrafters-io/kafka-tester/protocol"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
-func testMultiFetchFromDisk(stageHarness *test_case_harness.TestCaseHarness) error {
-	return fmt.Errorf("This stage is not implemented yet, we are working on it!")
+func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := kafka_executable.NewKafkaExecutable(stageHarness)
+	if err := b.Run(); err != nil {
+		return err
+	}
+
+	logger := stageHarness.Logger
+	err := serializer.GenerateLogDirs(logger)
+	if err != nil {
+		return err
+	}
+
+	correlationId := getRandomCorrelationId()
+
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, logger); err != nil {
+		return err
+	}
+	defer broker.Close()
+
+	request := kafkaapi.FetchRequest{
+		Header: kafkaapi.RequestHeader{
+			ApiKey:        1,
+			ApiVersion:    16,
+			CorrelationId: correlationId,
+			ClientId:      "kafka-cli",
+		},
+		Body: kafkaapi.FetchRequestBody{
+			MaxWaitMS:         500,
+			MinBytes:          1,
+			MaxBytes:          52428800,
+			IsolationLevel:    0,
+			FetchSessionID:    0,
+			FetchSessionEpoch: 0,
+			Topics: []kafkaapi.Topic{
+				{
+					TopicUUID: common.TOPIC3_UUID,
+					Partitions: []kafkaapi.Partition{
+						{
+							ID:                 0,
+							CurrentLeaderEpoch: -1,
+							FetchOffset:        0,
+							LastFetchedOffset:  -1,
+							LogStartOffset:     -1,
+							PartitionMaxBytes:  1048576,
+						},
+					},
+				},
+			},
+			ForgottenTopics: []kafkaapi.ForgottenTopic{},
+			RackID:          "",
+		},
+	}
+
+	message := kafkaapi.EncodeFetchRequest(&request)
+	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+
+	response, err := broker.SendAndReceive(message)
+	if err != nil {
+		return err
+	}
+	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	if err != nil {
+		return err
+	}
+
+	expectedResponseHeader := kafkaapi.ResponseHeader{
+		CorrelationId: correlationId,
+	}
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+		return err
+	}
+
+	expectedFetchResponse := kafkaapi.FetchResponse{
+		ThrottleTimeMs: 0,
+		ErrorCode:      0,
+		SessionID:      0,
+		TopicResponses: []kafkaapi.TopicResponse{
+			{
+				Topic: common.TOPIC3_UUID,
+				PartitionResponses: []kafkaapi.PartitionResponse{
+					{
+						PartitionIndex:      0,
+						ErrorCode:           0,
+						HighWatermark:       0,
+						LastStableOffset:    0,
+						LogStartOffset:      0,
+						AbortedTransactions: []kafkaapi.AbortedTransaction{},
+						RecordBatches: []kafkaapi.RecordBatch{
+							{
+								BaseOffset:           0,
+								BatchLength:          0,
+								PartitionLeaderEpoch: 0,
+								Magic:                0,
+								Attributes:           0,
+								LastOffsetDelta:      0,
+								FirstTimestamp:       0,
+								MaxTimestamp:         0,
+								ProducerId:           0,
+								ProducerEpoch:        0,
+								BaseSequence:         0,
+								Records: []kafkaapi.Record{
+									{
+										Length:         0,
+										Attributes:     0,
+										TimestampDelta: 0,
+										OffsetDelta:    0,
+										Key:            []byte{},
+										Value:          []byte(common.MESSAGE2),
+										Headers:        []kafkaapi.RecordHeader{},
+									},
+								},
+							},
+							{
+								BaseOffset:           1,
+								BatchLength:          0,
+								PartitionLeaderEpoch: 0,
+								Magic:                0,
+								Attributes:           0,
+								LastOffsetDelta:      0,
+								FirstTimestamp:       0,
+								MaxTimestamp:         0,
+								ProducerId:           0,
+								ProducerEpoch:        0,
+								BaseSequence:         0,
+								Records: []kafkaapi.Record{
+									{
+										Length:         0,
+										Attributes:     0,
+										TimestampDelta: 0,
+										OffsetDelta:    0,
+										Key:            []byte{},
+										Value:          []byte(common.MESSAGE3),
+										Headers:        []kafkaapi.RecordHeader{},
+									},
+								},
+							},
+						},
+						PreferedReadReplica: 0,
+					},
+				},
+			},
+		},
+	}
+
+	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
+		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).
+		AssertTopics([]string{"Topic"}, []string{"ErrorCode", "PartitionIndex"}, []string{"BaseOffset"}, []string{"Value"}).
+		Run()
 }

--- a/internal/test_helpers/fixtures/fetch/pass
+++ b/internal/test_helpers/fixtures/fetch/pass
@@ -6,15 +6,15 @@ Debug = true
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-4] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -394,15 +394,15 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -419,7 +419,7 @@ Debug = true
 [33m[stage-3] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 08 34 e5 4d 01 | `Z..........4.M.[0m
+[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 08 9b d1 a0 01 | `Z..............[0m
 [33m[stage-3] [0m[36m0010 | 00                                              | .[0m
 [33m[stage-3] [0m[36m[0m
 [33m[stage-3] [Decoder] [0m[36m- .ResponseHeader[0m
@@ -428,12 +428,13 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-3] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m  - .session_id (137684301)[0m
+[33m[stage-3] [Decoder] [0m[36m  - .session_id (144429472)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .num_responses (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-3] [0m[92m✓ Correlation ID: 1616512461[0m
-[33m[stage-3] [0m[92m✓ Error code: 0 (NO_ERROR)[0m
-[33m[stage-3] [0m[92m✓ Topic responses: [][0m
+[33m[stage-3] [0m[92m✓ Throttle Time: 0[0m
+[33m[stage-3] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponses: [][0m
 [33m[stage-3] [0m[92mTest passed.[0m
 [33m[stage-3] [0m[36mTerminating program[0m
 [33m[stage-3] [0m[36mProgram terminated successfully[0m
@@ -444,15 +445,15 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -464,7 +465,7 @@ Debug = true
 [33m[stage-2] [0m[36m0000 | 00 00 00 60 00 01 00 10 05 c3 b0 2a 00 09 6b 61 | ...`.......*..ka[0m
 [33m[stage-2] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-2] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 91 58 02 00 | .............X..[0m
+[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 15 49 02 00 | .............I..[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-2] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -472,8 +473,8 @@ Debug = true
 [33m[stage-2] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 0c 34 d2 e1 02 | ...*........4...[0m
-[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 91 58 | ...............X[0m
+[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 01 26 64 2c 02 | ...*........&d,.[0m
+[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 15 49 | ...............I[0m
 [33m[stage-2] [0m[36m0020 | 02 00 00 00 00 00 64 ff ff ff ff ff ff ff ff ff | ......d.........[0m
 [33m[stage-2] [0m[36m0030 | ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff 01 | ................[0m
 [33m[stage-2] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
@@ -484,10 +485,10 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-2] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m  - .session_id (204788449)[0m
+[33m[stage-2] [Decoder] [0m[36m  - .session_id (19293228)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000009158)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000001549)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-2] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -502,10 +503,12 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-2] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-2] [0m[92m✓ Correlation ID: 96710698[0m
-[33m[stage-2] [0m[92m✓ Error code: 0 (NO_ERROR)[0m
-[33m[stage-2] [0m[92m✓ Topic UUID: 00000000-0000-0000-0000-000000009158[0m
-[33m[stage-2] [0m[92m✓ PartitionResponse Error code: 100 (UNKNOWN_TOPIC_ID)[0m
-[33m[stage-2] [0m[92m✓ RecordBatches: [][0m
+[33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
+[33m[stage-2] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000001549[0m
+[33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 100 (UNKNOWN_TOPIC_ID)[0m
+[33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
+[33m[stage-2] [0m[92m    ✓ RecordBatches: [][0m
 [33m[stage-2] [0m[92mTest passed.[0m
 [33m[stage-2] [0m[36mTerminating program[0m
 [33m[stage-2] [0m[36mProgram terminated successfully[0m
@@ -516,15 +519,15 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -536,7 +539,7 @@ Debug = true
 [33m[stage-1] [0m[36m0000 | 00 00 00 60 00 01 00 10 0f 2e 14 fa 00 09 6b 61 | ...`..........ka[0m
 [33m[stage-1] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-1] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 19 02 00 | ....@...........[0m
+[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 37 02 00 | ....@........7..[0m
 [33m[stage-1] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-1] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -544,16 +547,11 @@ Debug = true
 [33m[stage-1] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 01 a4 fa ac 02 | ................[0m
-[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 19 | ......@.........[0m
-[33m[stage-1] [0m[36m0020 | 02 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 | ................[0m
-[33m[stage-1] [0m[36m0030 | 00 00 00 00 00 00 01 00 00 00 00 00 00 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0040 | ff ff ff ff 54 00 00 00 00 00 00 00 00 00 00 00 | ....T...........[0m
-[33m[stage-1] [0m[36m0050 | 47 00 00 00 00 02 b8 7c 9c ff 00 00 00 00 00 00 | G......|........[0m
-[33m[stage-1] [0m[36m0060 | 00 00 01 91 e0 5b 6d 8b 00 00 01 91 e0 5b 6d 8b | .....[m......[m.[0m
-[33m[stage-1] [0m[36m0070 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0080 | 00 01 2a 00 00 00 01 1e 48 65 6c 6c 6f 20 55 6e | ..*.....Hello Un[0m
-[33m[stage-1] [0m[36m0090 | 69 76 65 72 73 65 21 00 00 00 00                | iverse!....[0m
+[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 07 c3 37 a8 02 | .............7..[0m
+[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 37 | ......@........7[0m
+[33m[stage-1] [0m[36m0020 | 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
+[33m[stage-1] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
+[33m[stage-1] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
 [33m[stage-1] [0m[36m[0m
 [33m[stage-1] [Decoder] [0m[36m- .ResponseHeader[0m
 [33m[stage-1] [Decoder] [0m[36m  - .correlation_id (254678266)[0m
@@ -561,50 +559,30 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-1] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m  - .session_id (27589292)[0m
+[33m[stage-1] [Decoder] [0m[36m  - .session_id (130234280)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000019)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000037)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-1] [Decoder] [0m[36m      - .partition_index (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .high_watermark (1)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .last_stable_offset (1)[0m
+[33m[stage-1] [Decoder] [0m[36m      - .high_watermark (0)[0m
+[33m[stage-1] [Decoder] [0m[36m      - .last_stable_offset (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .log_start_offset (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .num_aborted_transactions (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .preferred_read_replica (-1)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .compact_records_length (83)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .RecordBatch[0][0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_offset (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .batch_length (71)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .partition_leader_epoch (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .magic_byte (2)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .crc (-1199792897)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .record_attributes (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .last_offset_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_timestamp (1726045973899)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .max_timestamp (1726045973899)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .producer_id (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .producer_epoch (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_sequence (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .num_records (1)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .Record[0][0m
-[33m[stage-1] [Decoder] [0m[36m          - .length (21)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .attributes (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .timestamp_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .offset_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .key_length (-1)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .key ("")[0m
-[33m[stage-1] [Decoder] [0m[36m          - .value_length (15)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .value ("Hello Universe!")[0m
-[33m[stage-1] [Decoder] [0m[36m          - .num_headers (0)[0m
+[33m[stage-1] [Decoder] [0m[36m      - .compact_records_length (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-1] [0m[92m✓ Correlation ID: 254678266[0m
-[33m[stage-1] [0m[92m✓ Error code: 0 (NO_ERROR)[0m
-[33m[stage-1] [0m[92m✓ Messages: ["Hello Universe!"][0m
+[33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
+[33m[stage-1] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000037[0m
+[33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
+[33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
+[33m[stage-1] [0m[92m    ✓ RecordBatches: [][0m
 [33m[stage-1] [0m[92mTest passed.[0m
 [33m[stage-1] [0m[36mTerminating program[0m
 [33m[stage-1] [0m[36mProgram terminated successfully[0m

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -54,15 +54,15 @@ var testerDefinition = tester_definition.TesterDefinition{
 		},
 		{
 			Slug:     "cm4",
-			TestFunc: testFetch,
+			TestFunc: testFetchNoMessages,
 		},
 		{
 			Slug:     "eg2",
-			TestFunc: testSingleFetchFromDisk,
+			TestFunc: testFetchWithSingleMessage,
 		},
 		{
 			Slug:     "fd8",
-			TestFunc: testMultiFetchFromDisk,
+			TestFunc: testFetchMultipleMessages,
 		},
 		{
 			Slug:     "yk1",


### PR DESCRIPTION
This pull request refactors the fetch response assertions and tests to improve code readability and maintainability. It includes the following changes:

- Added minimal FetchResponseAssertion for testing fetch responses

- Added assertions for recordBatch + Records in FetchResponseAssertion

- Improved error code logging in FetchResponseAssertion

- Utilized FetchResponseAssertion in f4

- Removed custom checks in f4, f2, and f3

- Added AssertNoTopics method to FetchResponseAssertion

- Called AssertNoTopics method in f2

- Updated error code string issue

- Added more error codes to mapping

- Updated testFetchNoMessages function in f4

- Added testFetchWithSingleMessage function in f5

- Added testFetchWithMultiMessages function in f6

- Set up tester prerequisites

These changes enhance the fetch response assertions and tests, making them more robust and easier to maintain.