### PR TITLE
Updates to kafka tester for DescribeTopicPartition extension

### DIFF
--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -53,20 +53,20 @@ func (a ApiVersionsResponseAssertion) Evaluate(fields []string, AssertApiVersion
 			for _, actualApiVersionKey := range a.ActualValue.ApiKeys {
 				if actualApiVersionKey.ApiKey == expectedApiVersionKey.ApiKey {
 					found = true
-					if actualApiVersionKey.MaxVersion < expectedApiVersionKey.MinVersion {
-						return fmt.Errorf("Expected max version %v to be >= min version %v for %s", actualApiVersionKey.MaxVersion, actualApiVersionKey.MinVersion, apiKeyNames[expectedApiVersionKey.ApiKey])
+					if actualApiVersionKey.MinVersion > expectedApiVersionKey.MaxVersion {
+						return fmt.Errorf("Expected min version %v to be < max version %v for %s", actualApiVersionKey.MinVersion, expectedApiVersionKey.MaxVersion, apiKeyNames[expectedApiVersionKey.ApiKey])
 					}
 
 					// anything above or equal to expected minVersion is fine
 					if actualApiVersionKey.MinVersion < expectedApiVersionKey.MinVersion {
 						return fmt.Errorf("Expected API version %v to be supported for %s, got %v", expectedApiVersionKey.MaxVersion, apiKeyNames[expectedApiVersionKey.ApiKey], actualApiVersionKey.MaxVersion)
 					}
-					logger.Successf("✓ API version %v is supported for %s", actualApiVersionKey.MaxVersion, apiKeyNames[expectedApiVersionKey.ApiKey])
+					logger.Successf("✓ MinVersion for %s is <= %v & >= %v", apiKeyNames[expectedApiVersionKey.ApiKey], expectedApiVersionKey.MaxVersion, expectedApiVersionKey.MinVersion)
 
 					if actualApiVersionKey.MaxVersion < expectedApiVersionKey.MaxVersion {
 						return fmt.Errorf("Expected API version %v to be supported for %s, got %v", expectedApiVersionKey.MaxVersion, apiKeyNames[expectedApiVersionKey.ApiKey], actualApiVersionKey.MaxVersion)
 					}
-					logger.Successf("✓ API version %v is supported for %s", actualApiVersionKey.MinVersion, apiKeyNames[expectedApiVersionKey.ApiKey])
+					logger.Successf("✓ MaxVersion for %s is >= %v", apiKeyNames[expectedApiVersionKey.ApiKey], expectedApiVersionKey.MaxVersion)
 				}
 			}
 			if !found {

--- a/internal/cluster_metadata_payload_test.go
+++ b/internal/cluster_metadata_payload_test.go
@@ -48,6 +48,8 @@ func TestDecodeFeatureLevelRecordPayload(t *testing.T) {
 	assert.EqualValues(t, 0, featureLevelRecord.Version)
 
 	payload, ok := featureLevelRecord.Data.(*kafkaapi.FeatureLevelRecord)
+	assert.EqualValues(t, "metadata.version", payload.Name)
+	assert.EqualValues(t, 20, payload.FeatureLevel)
 	assert.True(t, ok)
 	assert.EqualValues(t, "metadata.version", payload.Name)
 }
@@ -94,7 +96,7 @@ func TestDecodeEndTransactionRecordPayload(t *testing.T) {
 }
 
 func TestDecodeTopicRecordPayload(t *testing.T) {
-	hexdump := "01020004666f6fbfd99e5e3235455281f8d4af1741970c00"
+	hexdump := "0102000473617a0000000000004000800000000000009100"
 
 	b, err := hex.DecodeString(hexdump)
 	if err != nil {
@@ -111,12 +113,12 @@ func TestDecodeTopicRecordPayload(t *testing.T) {
 
 	payload, ok := topicRecord.Data.(*kafkaapi.TopicRecord)
 	assert.True(t, ok)
-	assert.EqualValues(t, "foo", payload.TopicName)
-	assert.EqualValues(t, "bfd99e5e-3235-4552-81f8-d4af1741970c", payload.TopicUUID)
+	assert.EqualValues(t, "saz", payload.TopicName)
+	assert.EqualValues(t, "00000000-0000-4000-8000-000000000091", payload.TopicUUID)
 }
 
 func TestDecodePartitionRecordPayload(t *testing.T) {
-	hexdump := "01030100000000bfd99e5e3235455281f8d4af1741970c020000000102000000010101000000010000000000000000020224973cbadd44cf874445a99619da3400"
+	hexdump := "0103010000000000000000000040008000000000000091020000000102000000010101000000010000000000000000021000000000004000800000000000000100"
 
 	b, err := hex.DecodeString(hexdump)
 	if err != nil {
@@ -134,7 +136,7 @@ func TestDecodePartitionRecordPayload(t *testing.T) {
 	payload, ok := partitionRecord.Data.(*kafkaapi.PartitionRecord)
 	assert.True(t, ok)
 	assert.EqualValues(t, 0, payload.PartitionID)
-	assert.EqualValues(t, "bfd99e5e-3235-4552-81f8-d4af1741970c", payload.TopicUUID)
+	assert.EqualValues(t, "00000000-0000-4000-8000-000000000091", payload.TopicUUID)
 	assert.EqualValues(t, []int32{1}, payload.Replicas)
 	assert.EqualValues(t, []int32{1}, payload.ISReplicas)
 	assert.EqualValues(t, []int32{}, payload.RemovingReplicas)
@@ -142,7 +144,7 @@ func TestDecodePartitionRecordPayload(t *testing.T) {
 	assert.EqualValues(t, 1, payload.Leader)
 	assert.EqualValues(t, 0, payload.LeaderEpoch)
 	assert.EqualValues(t, 0, payload.PartitionEpoch)
-	assert.EqualValues(t, []string{"0224973c-badd-44cf-8744-45a99619da34"}, payload.Directories)
+	assert.EqualValues(t, []string{"10000000-0000-4000-8000-000000000001"}, payload.Directories)
 }
 
 func TestEncodeBeginTransactionRecordPayload(t *testing.T) {

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -42,7 +42,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{
-					Name: "unknown-topic",
+					Name: common.TOPIC_UNKOWN_NAME,
 				},
 			},
 			ResponsePartitionLimit: 1,
@@ -56,6 +56,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	if err != nil {
 		return err
 	}
+	// ToDo: log inside sendAndReceive, else in failure cases, we won't log any
 	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
 	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
 

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -65,7 +65,7 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"topic_name":             {regexp.MustCompile(`- .topic_name \([A-Za-z0-9 ]{1,}\)`)},
 		"next_cursor":            {regexp.MustCompile(`- .next_cursor \(\{[A-Za-z0-9 ]{1,}\}\)`)},
 		"Messages":               {regexp.MustCompile(`✓ Messages: \["[A-Za-z !]{1,}"\]`)},
-		"Topic Name":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic Name: [A-Za-z]{3}`)},
+		"Topic Name":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic Name: [A-Za-z]{3,}`)},
 		"Topic UUID":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic UUID: [0-9 -]{1,}`)},
 	}
 

--- a/internal/test_helpers/fixtures/describe_topic_partitions/pass
+++ b/internal/test_helpers/fixtures/describe_topic_partitions/pass
@@ -365,10 +365,10 @@ Debug = true
 [33m[stage-5] [0m[92m✓ Correlation ID: 177586623[0m
 [33m[stage-5] [0m[92m✓ Error code: 0 (NO_ERROR)[0m
 [33m[stage-5] [0m[92m✓ API keys array length: 61[0m
-[33m[stage-5] [0m[92m✓ API version 4 is supported for API_VERSIONS[0m
-[33m[stage-5] [0m[92m✓ API version 0 is supported for API_VERSIONS[0m
-[33m[stage-5] [0m[92m✓ API version 0 is supported for DESCRIBE_TOPIC_PARTITIONS[0m
-[33m[stage-5] [0m[92m✓ API version 0 is supported for DESCRIBE_TOPIC_PARTITIONS[0m
+[33m[stage-5] [0m[92m✓ MinVersion for API_VERSIONS is <= 4 & >= 0[0m
+[33m[stage-5] [0m[92m✓ MaxVersion for API_VERSIONS is >= 4[0m
+[33m[stage-5] [0m[92m✓ MinVersion for DESCRIBE_TOPIC_PARTITIONS is <= 0 & >= 0[0m
+[33m[stage-5] [0m[92m✓ MaxVersion for DESCRIBE_TOPIC_PARTITIONS is >= 0[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 [33m[stage-5] [0m[36mTerminating program[0m
 [33m[stage-5] [0m[36mProgram terminated successfully[0m
@@ -381,18 +381,18 @@ Debug = true
 [33m[stage-4] [0m[36mHexdump of sent "DescribeTopicPartitions" request: [0m
 [33m[stage-4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-4] [0m[36m0000 | 00 00 00 2d 00 4b 00 00 60 5a 05 cd 00 0c 6b 61 | ...-.K..`Z....ka[0m
-[33m[stage-4] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 0e 75 6e 6b | fka-tester...unk[0m
-[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 00 00 00 00 01 ff | nown-topic......[0m
-[33m[stage-4] [0m[36m0030 | 00                                              | .[0m
+[33m[stage-4] [0m[36m0000 | 00 00 00 31 00 4b 00 00 60 5a 05 cd 00 0c 6b 61 | ...1.K..`Z....ka[0m
+[33m[stage-4] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 12 75 6e 6b | fka-tester...unk[0m
+[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 73 61 7a 00 00 | nown-topic-saz..[0m
+[33m[stage-4] [0m[36m0030 | 00 00 01 ff 00                                  | .....[0m
 [33m[stage-4] [0m[36m[0m
 [33m[stage-4] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-4] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 02 00 03 0e 75 6e 6b | `Z...........unk[0m
-[33m[stage-4] [0m[36m0010 | 6e 6f 77 6e 2d 74 6f 70 69 63 00 00 00 00 00 00 | nown-topic......[0m
-[33m[stage-4] [0m[36m0020 | 00 00 00 00 00 00 00 00 00 00 00 01 00 00 0d f8 | ................[0m
-[33m[stage-4] [0m[36m0030 | 00 ff 00                                        | ...[0m
+[33m[stage-4] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 02 00 03 12 75 6e 6b | `Z...........unk[0m
+[33m[stage-4] [0m[36m0010 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 73 61 7a 00 00 | nown-topic-saz..[0m
+[33m[stage-4] [0m[36m0020 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 | ................[0m
+[33m[stage-4] [0m[36m0030 | 00 00 0d f8 00 ff 00                            | .......[0m
 [33m[stage-4] [0m[36m[0m
 [33m[stage-4] [Decoder] [0m[36m- .ResponseHeader[0m
 [33m[stage-4] [Decoder] [0m[36m  - .correlation_id (1616512461)[0m
@@ -402,7 +402,7 @@ Debug = true
 [33m[stage-4] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-4] [Decoder] [0m[36m    - .error_code (3)[0m
-[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic)[0m
+[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic-saz)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000000000)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .num_partitions (0)[0m
@@ -413,7 +413,7 @@ Debug = true
 [33m[stage-4] [0m[92m✓ Correlation ID: 1616512461[0m
 [33m[stage-4] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Error code: 3[0m
-[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic[0m
+[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic-saz[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000000000[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 [33m[stage-4] [0m[36mTerminating program[0m
@@ -425,15 +425,15 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -443,14 +443,14 @@ Debug = true
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-3] [0m[36m0000 | 00 00 00 23 00 4b 00 00 05 c3 b0 2a 00 0c 6b 61 | ...#.K.....*..ka[0m
-[33m[stage-3] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 62 61 72 | fka-tester...bar[0m
+[33m[stage-3] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 70 61 78 | fka-tester...pax[0m
 [33m[stage-3] [0m[36m0020 | 00 00 00 00 01 ff 00                            | .......[0m
 [33m[stage-3] [0m[36m[0m
 [33m[stage-3] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 02 00 00 04 62 61 72 | ...*.........bar[0m
-[33m[stage-3] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 87 | ......@.........[0m
+[33m[stage-3] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 02 00 00 04 70 61 78 | ...*.........pax[0m
+[33m[stage-3] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 45 | ......@........E[0m
 [33m[stage-3] [0m[36m0020 | 00 02 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0040 | 0d f8 00 ff 00                                  | .....[0m
@@ -463,8 +463,8 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-3] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m    - .name (bar)[0m
-[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000087)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .name (pax)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000045)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -485,8 +485,8 @@ Debug = true
 [33m[stage-3] [0m[92m✓ Correlation ID: 96710698[0m
 [33m[stage-3] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-3] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000087[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic Name: pax[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000045[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 [33m[stage-3] [0m[36mTerminating program[0m
 [33m[stage-3] [0m[36mProgram terminated successfully[0m
@@ -497,15 +497,15 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -515,14 +515,14 @@ Debug = true
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-2] [0m[36m0000 | 00 00 00 23 00 4b 00 00 0f 2e 14 fa 00 0c 6b 61 | ...#.K........ka[0m
-[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 73 61 7a | fka-tester...saz[0m
+[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 71 75 7a | fka-tester...quz[0m
 [33m[stage-2] [0m[36m0020 | 00 00 00 00 02 ff 00                            | .......[0m
 [33m[stage-2] [0m[36m[0m
 [33m[stage-2] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 02 00 00 04 73 61 7a | .............saz[0m
-[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 58 | ......@........X[0m
+[33m[stage-2] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 02 00 00 04 71 75 7a | .............quz[0m
+[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 11 | ......@.........[0m
 [33m[stage-2] [0m[36m0020 | 00 03 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 01 00 00 00 01 00 00 00 00 02 00 00 00 | ................[0m
@@ -537,8 +537,8 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-2] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .name (saz)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .name (quz)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000011)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -570,8 +570,8 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: saz[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: quz[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000011[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m
@@ -586,15 +586,15 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/saz-1/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -604,23 +604,23 @@ Debug = true
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-1] [0m[36m0000 | 00 00 00 2d 00 4b 00 00 70 d8 81 15 00 0c 6b 61 | ...-.K..p.....ka[0m
-[33m[stage-1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 04 04 62 61 72 | fka-tester...bar[0m
-[33m[stage-1] [0m[36m0020 | 00 04 71 75 7a 00 04 73 61 7a 00 00 00 00 04 ff | ..quz..saz......[0m
+[33m[stage-1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 04 04 70 61 78 | fka-tester...pax[0m
+[33m[stage-1] [0m[36m0020 | 00 04 70 61 7a 00 04 71 75 7a 00 00 00 00 04 ff | ..paz..quz......[0m
 [33m[stage-1] [0m[36m0030 | 00                                              | .[0m
 [33m[stage-1] [0m[36m[0m
 [33m[stage-1] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 70 d8 81 15 00 00 00 00 00 04 00 00 04 62 61 72 | p............bar[0m
-[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 87 | ......@.........[0m
+[33m[stage-1] [0m[36m0000 | 70 d8 81 15 00 00 00 00 00 04 00 00 04 70 61 78 | p............pax[0m
+[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 45 | ......@........E[0m
 [33m[stage-1] [0m[36m0020 | 00 02 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0040 | 0d f8 00 00 00 04 71 75 7a 00 00 00 00 00 00 40 | ......quz......@[0m
-[33m[stage-1] [0m[36m0050 | 00 80 00 00 00 00 00 00 54 00 02 00 00 00 00 00 | ........T.......[0m
+[33m[stage-1] [0m[36m0040 | 0d f8 00 00 00 04 70 61 7a 00 00 00 00 00 00 40 | ......paz......@[0m
+[33m[stage-1] [0m[36m0050 | 00 80 00 00 00 00 00 00 58 00 02 00 00 00 00 00 | ........X.......[0m
 [33m[stage-1] [0m[36m0060 | 00 00 00 00 01 00 00 00 00 02 00 00 00 01 02 00 | ................[0m
-[33m[stage-1] [0m[36m0070 | 00 00 01 01 01 01 00 00 00 0d f8 00 00 00 04 73 | ...............s[0m
-[33m[stage-1] [0m[36m0080 | 61 7a 00 00 00 00 00 00 40 00 80 00 00 00 00 00 | az......@.......[0m
-[33m[stage-1] [0m[36m0090 | 00 58 00 03 00 00 00 00 00 00 00 00 00 01 00 00 | .X..............[0m
+[33m[stage-1] [0m[36m0070 | 00 00 01 01 01 01 00 00 00 0d f8 00 00 00 04 71 | ...............q[0m
+[33m[stage-1] [0m[36m0080 | 75 7a 00 00 00 00 00 00 40 00 80 00 00 00 00 00 | uz......@.......[0m
+[33m[stage-1] [0m[36m0090 | 00 11 00 03 00 00 00 00 00 00 00 00 00 01 00 00 | ................[0m
 [33m[stage-1] [0m[36m00a0 | 00 00 02 00 00 00 01 02 00 00 00 01 01 01 01 00 | ................[0m
 [33m[stage-1] [0m[36m00b0 | 00 00 00 00 00 01 00 00 00 01 00 00 00 00 02 00 | ................[0m
 [33m[stage-1] [0m[36m00c0 | 00 00 01 02 00 00 00 01 01 01 01 00 00 00 0d f8 | ................[0m
@@ -634,8 +634,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m  - .topic.length (3)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (bar)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000087)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (pax)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000045)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -653,8 +653,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[1][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (quz)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000054)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (paz)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -672,8 +672,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[2][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (saz)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (quz)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000011)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -705,18 +705,18 @@ Debug = true
 [33m[stage-1] [0m[92m✓ Correlation ID: 1893237013[0m
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000087[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic Name: pax[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000045[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[1] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: quz[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000054[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: paz[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[2] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: saz[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: quz[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000011[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m

--- a/internal/test_helpers/fixtures/fetch/pass
+++ b/internal/test_helpers/fixtures/fetch/pass
@@ -6,15 +6,15 @@ Debug = true
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-4] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -61,7 +61,7 @@ Debug = true
 [33m[stage-4] [0m[36m01c0 | 2e 76 65 72 73 69 6f 6e 00 00 00 01 00 0e 6b 72 | .version......kr[0m
 [33m[stage-4] [0m[36m01d0 | 61 66 74 2e 76 65 72 73 69 6f 6e 00 00 00 01 00 | aft.version.....[0m
 [33m[stage-4] [0m[36m01e0 | 11 6d 65 74 61 64 61 74 61 2e 76 65 72 73 69 6f | .metadata.versio[0m
-[33m[stage-4] [0m[36m01f0 | 6e 00 01 00 16 00 01 08 00 00 00 00 00 00 00 0c | n...............[0m
+[33m[stage-4] [0m[36m01f0 | 6e 00 01 00 16 00 01 08 00 00 00 00 00 00 00 0b | n...............[0m
 [33m[stage-4] [0m[36m0200 | 02 17 02 11 6d 65 74 61 64 61 74 61 2e 76 65 72 | ....metadata.ver[0m
 [33m[stage-4] [0m[36m0210 | 73 69 6f 6e 00 14 00 14 00                      | sion.....[0m
 [33m[stage-4] [0m[36m[0m
@@ -380,10 +380,10 @@ Debug = true
 [33m[stage-4] [0m[92m✓ Correlation ID: 177586623[0m
 [33m[stage-4] [0m[92m✓ Error code: 0 (NO_ERROR)[0m
 [33m[stage-4] [0m[92m✓ API keys array length: 61[0m
-[33m[stage-4] [0m[92m✓ API version 17 is supported for FETCH[0m
-[33m[stage-4] [0m[92m✓ API version 0 is supported for FETCH[0m
-[33m[stage-4] [0m[92m✓ API version 4 is supported for API_VERSIONS[0m
-[33m[stage-4] [0m[92m✓ API version 0 is supported for API_VERSIONS[0m
+[33m[stage-4] [0m[92m✓ MinVersion for FETCH is <= 16 & >= 0[0m
+[33m[stage-4] [0m[92m✓ MaxVersion for FETCH is >= 16[0m
+[33m[stage-4] [0m[92m✓ MinVersion for API_VERSIONS is <= 4 & >= 0[0m
+[33m[stage-4] [0m[92m✓ MaxVersion for API_VERSIONS is >= 4[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 [33m[stage-4] [0m[36mTerminating program[0m
 [33m[stage-4] [0m[36mProgram terminated successfully[0m
@@ -394,15 +394,15 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -419,7 +419,7 @@ Debug = true
 [33m[stage-3] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 08 9b d1 a0 01 | `Z..............[0m
+[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 0f 58 2f fb 01 | `Z..........X/..[0m
 [33m[stage-3] [0m[36m0010 | 00                                              | .[0m
 [33m[stage-3] [0m[36m[0m
 [33m[stage-3] [Decoder] [0m[36m- .ResponseHeader[0m
@@ -428,7 +428,7 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-3] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m  - .session_id (144429472)[0m
+[33m[stage-3] [Decoder] [0m[36m  - .session_id (257437691)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .num_responses (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-3] [0m[92m✓ Correlation ID: 1616512461[0m
@@ -445,15 +445,15 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -465,7 +465,7 @@ Debug = true
 [33m[stage-2] [0m[36m0000 | 00 00 00 60 00 01 00 10 05 c3 b0 2a 00 09 6b 61 | ...`.......*..ka[0m
 [33m[stage-2] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-2] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 15 49 02 00 | .............I..[0m
+[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 42 08 02 00 | ............B...[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-2] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -473,8 +473,8 @@ Debug = true
 [33m[stage-2] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 01 26 64 2c 02 | ...*........&d,.[0m
-[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 15 49 | ...............I[0m
+[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 0f 88 6e 28 02 | ...*.........n(.[0m
+[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 42 08 | ..............B.[0m
 [33m[stage-2] [0m[36m0020 | 02 00 00 00 00 00 64 ff ff ff ff ff ff ff ff ff | ......d.........[0m
 [33m[stage-2] [0m[36m0030 | ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff 01 | ................[0m
 [33m[stage-2] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
@@ -485,10 +485,10 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-2] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m  - .session_id (19293228)[0m
+[33m[stage-2] [Decoder] [0m[36m  - .session_id (260599336)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000001549)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000004208)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-2] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -505,7 +505,7 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 96710698[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000001549[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000004208[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 100 (UNKNOWN_TOPIC_ID)[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m    ✓ RecordBatches: [][0m
@@ -519,15 +519,15 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -539,7 +539,7 @@ Debug = true
 [33m[stage-1] [0m[36m0000 | 00 00 00 60 00 01 00 10 0f 2e 14 fa 00 09 6b 61 | ...`..........ka[0m
 [33m[stage-1] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-1] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 37 02 00 | ....@........7..[0m
+[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 58 02 00 | ....@........X..[0m
 [33m[stage-1] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-1] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -547,8 +547,8 @@ Debug = true
 [33m[stage-1] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 07 c3 37 a8 02 | .............7..[0m
-[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 37 | ......@........7[0m
+[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 0a a5 d9 23 02 | ..............#.[0m
+[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 58 | ......@........X[0m
 [33m[stage-1] [0m[36m0020 | 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
@@ -559,10 +559,10 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-1] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m  - .session_id (130234280)[0m
+[33m[stage-1] [Decoder] [0m[36m  - .session_id (178641187)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000037)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-1] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -579,7 +579,7 @@ Debug = true
 [33m[stage-1] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000037[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m    ✓ RecordBatches: [][0m

--- a/protocol/api/spec.yml
+++ b/protocol/api/spec.yml
@@ -1,0 +1,349 @@
+data:
+  # RecordBatch[0]
+  - 0x00 # Base Offset (8 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x00 # Batch Length (4 bytes, 0x4f in hex, 79 in decimal)
+  - 0x00
+  - 0x00
+  - 0x4f
+  - 0x00 # Partition Leader Epoch (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x02 # Magic Byte (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x96 # CRC (4 bytes, 0x9654b1a5 in hex, -1772834395 in decimal)
+  - 0x54
+  - 0xb1
+  - 0xa5
+  - 0x00 # Attributes (2 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Last Offset Delta (4 bytes, 0x03 in hex, 3 in decimal)
+  - 0x00
+  - 0x00
+  - 0x03
+  - 0x00 # Base Timestamp (8 bytes, 0x00000191e05af818 in hex, 1726045943832 in decimal)
+  - 0x00
+  - 0x01
+  - 0x91
+  - 0xe0
+  - 0x5a
+  - 0xf8
+  - 0x18
+  - 0x00 # Max Timestamp (8 bytes, 0x00000191e05af818 in hex, 1726045943832 in decimal)
+  - 0x00
+  - 0x01
+  - 0x91
+  - 0xe0
+  - 0x5a
+  - 0xf8
+  - 0x18
+  - 0xff # Producer ID (8 bytes, 0xffffffffffffffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff  
+  - 0xff # Producer Epoch (2 bytes, 0xffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff # Base Sequence (4 bytes, 0xffffffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0x00 # Records Length (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+
+  # Record[0]
+  - 0x3a # Record Length (1 byte, 0x3a in hex, 29 in decimal (as signed varint)) (Length from attributes to the end of the record)
+  - 0x00 # Attributes (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Timestamp Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Offset Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x01 # Key Length (1 byte, 0x01 in hex, -1 in decimal (as signed varint, using zigzag encoding, refer to: https://protobuf.dev/programming-guides/encoding/#signed-ints))
+  # As key length is -1, the key value is empty
+  - 0x2e # Value Length (1 byte, 0x2e in hex, 23 in decimal (as signed varint))
+  # Payload: Feature Level Record
+  - 0x01 # Frame Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x0c # Type (1 byte, 0x0c in hex, 12 in decimal)
+  - 0x00 # Version (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x11 # Name Length (1 byte, 0x11 in hex, 17 in decimal (as unsigned varint))
+  - 0x6d # Name (Compact String (Length = 17 - 1), parsed as "metadata.version")
+  - 0x65
+  - 0x74
+  - 0x61
+  - 0x64
+  - 0x61
+  - 0x74
+  - 0x61
+  - 0x2e
+  - 0x76
+  - 0x65
+  - 0x72
+  - 0x73
+  - 0x69
+  - 0x6f
+  - 0x6e
+  - 0x00 # Feature Level (2 bytes, 0x14 in hex, 20 in decimal)
+  - 0x14
+  - 0x00 # Tagged Field Count (1 byte, 0x00 in hex, 0 in decimal) (unsigned varint)
+
+  # RecordBatch[1]
+  - 0x00 # Base Offset (8 bytes, 0x02 in hex, 2 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00 # Batch Length (4 bytes, 0xe4 in hex, 228 in decimal)
+  - 0x00
+  - 0x00
+  - 0xe4
+  - 0x00 # Partition Leader Epoch (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x02 # Magic Byte (1 byte, 0x02 in hex, 2 in decimal)
+  - 0xeb # CRC (4 bytes, 0xeb602a9d in hex, -346019171 in decimal)
+  - 0x60
+  - 0x2a
+  - 0x9d
+  - 0x00 # Attributes (2 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00 # Last Offset Delta (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x00 # Base Timestamp (8 bytes, 0x00000191e05b2d15 in hex, 1726045957397 in decimal)
+  - 0x00
+  - 0x01
+  - 0x91
+  - 0xe0
+  - 0x5b
+  - 0x2d
+  - 0x15
+  - 0x00 # Max Timestamp (8 bytes, 0x00000191e05b2d15 in hex, 1726045957397 in decimal)
+  - 0x00
+  - 0x01
+  - 0x91
+  - 0xe0
+  - 0x5b
+  - 0x2d
+  - 0x15
+  - 0xff # Producer ID (8 bytes, 0xffffffffffffffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0xff  
+  - 0xff # Producer Epoch (2 bytes, 0xffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff # Base Sequence (4 bytes, 0xffffffff in hex, -1 in decimal)
+  - 0xff
+  - 0xff
+  - 0xff
+  - 0x00 # Records Length (4 bytes, 0x02 in hex, 2 in decimal)
+  - 0x00
+  - 0x00
+  - 0x03
+
+  # Record[0]
+  - 0x3c # Record Length (1 byte, 0x3c in hex, 30 in decimal (as signed varint)) (Length from attributes to the end of the record)
+  - 0x00 # Attributes (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Timestamp Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Offset Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x01 # Key Length (1 byte, 0x01 in hex, -1 in decimal (as signed varint, using zigzag encoding, refer to: https://protobuf.dev/programming-guides/encoding/#signed-ints))
+  # As key length is -1, the key value is empty
+  - 0x30 # Value Length (1 byte, 0x30 in hex, 24 in decimal (as signed varint))
+  # Payload: Topic Record
+  - 0x01 # Frame Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x02 # Type (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x00 # Version (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x04 # Name Length (1 byte, 0x04 in hex, 4 in decimal (as unsigned varint))
+  - 0x73 # Topic Name (Compact String (Length = 4 - 1), parsed as "saz")
+  - 0x61
+  - 0x7a
+  - 0x00 # Topic UUID (16 raw bytes, 00000000-0000-4000-8000-000000000091 after parsing)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x40
+  - 0x00
+  - 0x80
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x91
+  - 0x00 # Tagged Field Count (1 byte, 0x00 in hex, 0 in decimal) (unsigned varint)
+
+  # Record[1]
+  - 0x90 # Record Length (1 byte, 0x9001 in hex, 72 in decimal (as signed varint)) (Length from attributes to the end of the record)
+  - 0x01
+  - 0x00 # Attributes (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Timestamp Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x02 # Offset Delta (1 byte, 0x02 in hex, 1 in decimal (as signed varint))
+  - 0x01 # Key Length (1 byte, 0x01 in hex, -1 in decimal (as signed varint, using zigzag encoding, refer to: https://protobuf.dev/programming-guides/encoding/#signed-ints))
+  # As key length is -1, the key value is empty
+  - 0x82 # Value Length (2 bytes, 0x8201 in hex, 65 in decimal (as signed varint))
+  - 0x01
+  # Payload: Partition Record
+  - 0x01 # Frame Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x03 # Type (1 byte, 0x03 in hex, 3 in decimal)
+  - 0x01 # Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x00 # Partition ID (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01 
+  - 0x00 # Topic UUID (16 raw bytes, 00000000-0000-4000-8000-000000000091 after parsing)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x40
+  - 0x00
+  - 0x80
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x91
+  - 0x02 # Length of Replica array (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x00 # Replica array (1 element, length = (2-1), each element is 4 bytes)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x02 # Length of In Sync Replica array (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x00 # In Sync Replica array (1 element, length = (2-1), each element is 4 bytes)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x01 # Length of Removing Replicas array (1 byte, 0x01 in hex, 1 in decimal, actual length = (1 - 1 = 0))
+  - 0x01 # Length of Adding Replicas array (1 byte, 0x01 in hex, 1 in decimal, actual length = (1 - 1 = 0))
+  - 0x00 # Leader (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x00 # Leader Epoch (4 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00 # Partition Epoch (4 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x02 # Compact Array Length (1 byte, 0x02 in hex, 1 in decimal (parsed as an unsigned varint))
+  - 0x10 # Directory UUID (16 raw bytes, 10000000-0000-4000-8000-000000000001 after parsing)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x40
+  - 0x00
+  - 0x80
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x01 
+  - 0x00 # Tagged Field Count (1 byte, 0x00 in hex, 0 in decimal) (unsigned varint)
+
+  # Record[2]
+  - 0x90 # Record Length (1 byte, 0x9001 in hex, 72 in decimal (as signed varint)) (Length from attributes to the end of the record)
+  - 0x01
+  - 0x00 # Attributes (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x00 # Timestamp Delta (1 byte, 0x00 in hex, 0 in decimal)
+  - 0x04 # Offset Delta (1 byte, 0x04 in hex, 2 in decimal (as signed varint))
+  - 0x01 # Key Length (1 byte, 0x01 in hex, -1 in decimal (as signed varint, using zigzag encoding, refer to: https://protobuf.dev/programming-guides/encoding/#signed-ints))
+  # As key length is -1, the key value is empty
+  - 0x82 # Value Length (2 bytes, 0x8201 in hex, 65 in decimal (as signed varint))
+  - 0x01
+
+  # Payload: Partition Record
+  - 0x01 # Frame Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x03 # Type (1 byte, 0x03 in hex, 3 in decimal)
+  - 0x01 # Version (1 byte, 0x01 in hex, 1 in decimal)
+  - 0x00 # Partition ID (4 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00 
+  - 0x00 # Topic UUID (16 raw bytes, 00000000-0000-4000-8000-000000000091 after parsing)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x40
+  - 0x00
+  - 0x80
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x91
+  - 0x02 # Length of Replica array (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x00 # Replica array (1 element, length = (2-1), each element is 4 bytes)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x02 # Length of In Sync Replica array (1 byte, 0x02 in hex, 2 in decimal)
+  - 0x00 # In Sync Replica array (1 element, length = (2-1), each element is 4 bytes)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x01 # Length of Removing Replicas array (1 byte, 0x01 in hex, 1 in decimal, actual length = (1 - 1 = 0))
+  - 0x01 # Length of Adding Replicas array (1 byte, 0x01 in hex, 1 in decimal, actual length = (1 - 1 = 0))
+  - 0x00 # Leader (4 bytes, 0x01 in hex, 1 in decimal)
+  - 0x00
+  - 0x00
+  - 0x01
+  - 0x00 # Leader Epoch (4 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00 # Partition Epoch (4 bytes, 0x00 in hex, 0 in decimal)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x02 # Compact Array Length (1 byte, 0x02 in hex, 1 in decimal (parsed as an unsigned varint))
+  - 0x10 # Directory UUID (16 raw bytes, 10000000-0000-4000-8000-000000000001 after parsing)
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x40
+  - 0x00
+  - 0x80
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x00
+  - 0x01 
+  - 0x00 # Number of Headers (1 byte, 0x00 in hex, 0 in decimal) 
+  // ToDo Do paylaods have headers or tagged fields ?

--- a/protocol/common/constants.go
+++ b/protocol/common/constants.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	all_topic_names = []string{"foo", "bar", "baz", "qux", "quz", "pax", "paz", "saz"}
-	topic_names     = GetSortedValues(random.RandomElementsFromArray(all_topic_names, 3))
+	topic_names     = GetSortedValues(random.RandomElementsFromArray(all_topic_names, 4))
 	TOPIC1_NAME     = topic_names[0]
 	TOPIC2_NAME     = topic_names[1]
 	TOPIC3_NAME     = topic_names[2]
@@ -30,7 +30,7 @@ var (
 	TOPIC3_UUID     = fmt.Sprintf("00000000-0000-4000-8000-0000000000%02d", random.RandomInt(10, 99))
 	TOPICX_UUID     = fmt.Sprintf("00000000-0000-0000-0000-00000000%04d", random.RandomInt(1000, 9999)) // Unknown topic used in requests
 
-	TOPIC_UNKOWN_NAME = "unknown-topic"
+	TOPIC_UNKOWN_NAME = fmt.Sprintf("unknown-topic-%s", topic_names[3])
 	TOPIC_UNKOWN_UUID = "00000000-0000-0000-0000-000000000000"
 
 	all_messages = []string{"Hello World!", "Hello Earth!", "Hello Reverse Engineering!", "Hello Universe!", "Hello Kafka!", "Hello CodeCrafters!"}

--- a/protocol/serializer/cluster_metadata_binspec.go
+++ b/protocol/serializer/cluster_metadata_binspec.go
@@ -1,0 +1,142 @@
+package serializer
+
+import (
+	"fmt"
+	"os"
+
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	kafkaencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+func writeClusterMetadataBinSpec(path string, directoryUUID string, logger *logger.Logger) error {
+	encoder := kafkaencoder.RealEncoder{}
+	encoder.Init(make([]byte, 40960))
+
+	topic3Name := "saz"
+	topic3UUID := "00000000-0000-4000-8000-000000000091"
+
+	featureLevelRecord := kafkaapi.ClusterMetadataPayload{
+		FrameVersion: 1,
+		Type:         12,
+		Version:      0,
+		Data: &kafkaapi.FeatureLevelRecord{
+			Name:         "metadata.version",
+			FeatureLevel: 20,
+		},
+	}
+
+	topicRecord3 := kafkaapi.ClusterMetadataPayload{
+		FrameVersion: 1,
+		Type:         2,
+		Version:      0,
+		Data: &kafkaapi.TopicRecord{
+			TopicName: topic3Name,
+			TopicUUID: topic3UUID,
+		},
+	}
+
+	partitionRecord3 := kafkaapi.ClusterMetadataPayload{
+		FrameVersion: 1,
+		Type:         3,
+		Version:      1,
+		Data: &kafkaapi.PartitionRecord{
+			PartitionID:      1,
+			TopicUUID:        topic3UUID,
+			Replicas:         []int32{1},
+			ISReplicas:       []int32{1},
+			RemovingReplicas: []int32{},
+			AddingReplicas:   []int32{},
+			Leader:           1,
+			LeaderEpoch:      0,
+			PartitionEpoch:   0,
+			Directories:      []string{directoryUUID},
+		},
+	}
+
+	partitionRecord4 := kafkaapi.ClusterMetadataPayload{
+		FrameVersion: 1,
+		Type:         3,
+		Version:      1,
+		Data: &kafkaapi.PartitionRecord{
+			PartitionID:      0,
+			TopicUUID:        topic3UUID,
+			Replicas:         []int32{1},
+			ISReplicas:       []int32{1},
+			RemovingReplicas: []int32{},
+			AddingReplicas:   []int32{},
+			Leader:           1,
+			LeaderEpoch:      0,
+			PartitionEpoch:   0,
+			Directories:      []string{directoryUUID},
+		},
+	}
+
+	recordBatch1 := kafkaapi.RecordBatch{
+		BaseOffset:           1,
+		PartitionLeaderEpoch: 1,
+		Attributes:           0,
+		LastOffsetDelta:      3,
+		FirstTimestamp:       1726045943832,
+		MaxTimestamp:         1726045943832,
+		ProducerId:           -1,
+		ProducerEpoch:        -1,
+		BaseSequence:         -1,
+		Records: []kafkaapi.Record{
+			{
+				Attributes:     0,
+				TimestampDelta: 0,
+				Key:            nil,
+				Value:          GetEncodedBytes(featureLevelRecord),
+				Headers:        []kafkaapi.RecordHeader{},
+			},
+		},
+	}
+
+	recordBatch4 := kafkaapi.RecordBatch{
+		BaseOffset:           int64(0 + 0),
+		PartitionLeaderEpoch: 1,
+		Attributes:           0,
+		LastOffsetDelta:      1,
+		FirstTimestamp:       1726045957397,
+		MaxTimestamp:         1726045957397,
+		ProducerId:           -1,
+		ProducerEpoch:        -1,
+		BaseSequence:         -1,
+		Records: []kafkaapi.Record{
+			{
+				Attributes:     0,
+				TimestampDelta: 0,
+				Key:            nil,
+				Value:          GetEncodedBytes(topicRecord3),
+				Headers:        []kafkaapi.RecordHeader{},
+			},
+			{
+				Attributes:     0,
+				TimestampDelta: 0,
+				Key:            nil,
+				Value:          GetEncodedBytes(partitionRecord3),
+				Headers:        []kafkaapi.RecordHeader{},
+			},
+			{
+				Attributes:     0,
+				TimestampDelta: 0,
+				Key:            nil,
+				Value:          GetEncodedBytes(partitionRecord4),
+				Headers:        []kafkaapi.RecordHeader{},
+			},
+		},
+	}
+
+	recordBatch1.Encode(&encoder)
+	recordBatch4.Encode(&encoder)
+	encodedBytes := encoder.Bytes()[:encoder.Offset()]
+
+	err := os.WriteFile(path, encodedBytes, 0644)
+	if err != nil {
+		return fmt.Errorf("error writing file to %s: %w", path, err)
+	}
+
+	logger.Debugf("  - Wrote file to: %s", path)
+	return nil
+}


### PR DESCRIPTION
This pull request includes the following changes:

- Added a new binspec cluster metadata generator and spec

- Updated cluster metadata payload tests

- Added randomized unknown topic names

- Refactored values in the serializer for cluster metadata