### PR TITLE
Refactor generateLogDirs method to accept a parameter for skipping writing topic directory data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ main.go
 internal/test_helpers/ryan/**
 internal/assertion.go
 internal/assertions/topic_assertion.go
+protocol/api/spec.yml
+protocol/api/backupHex.sh

--- a/internal/stage1.go
+++ b/internal/stage1.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/internal/test_cases"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -13,8 +14,9 @@ func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage1.go
+++ b/internal/stage1.go
@@ -14,7 +14,7 @@ func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage2.go
+++ b/internal/stage2.go
@@ -20,7 +20,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage2.go
+++ b/internal/stage2.go
@@ -10,6 +10,7 @@ import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -19,8 +20,9 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage3.go
+++ b/internal/stage3.go
@@ -20,7 +20,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage3.go
+++ b/internal/stage3.go
@@ -10,6 +10,7 @@ import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -19,8 +20,9 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -19,7 +19,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage4.go
+++ b/internal/stage4.go
@@ -9,6 +9,7 @@ import (
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -18,8 +19,9 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage5.go
+++ b/internal/stage5.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -16,8 +17,9 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stage5.go
+++ b/internal/stage5.go
@@ -17,7 +17,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagec1.go
+++ b/internal/stagec1.go
@@ -18,7 +18,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagec1.go
+++ b/internal/stagec1.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -17,8 +18,9 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagec2.go
+++ b/internal/stagec2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -18,8 +19,9 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagec2.go
+++ b/internal/stagec2.go
@@ -19,7 +19,7 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef1.go
+++ b/internal/stagef1.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -15,8 +16,9 @@ func testAPIVersionwFetchKey(stageHarness *test_case_harness.TestCaseHarness) er
 		return err
 	}
 
+	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, false)
+	err := serializer.GenerateLogDirs(quietLogger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef1.go
+++ b/internal/stagef1.go
@@ -16,7 +16,7 @@ func testAPIVersionwFetchKey(stageHarness *test_case_harness.TestCaseHarness) er
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef2.go
+++ b/internal/stagef2.go
@@ -16,7 +16,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef3.go
+++ b/internal/stagef3.go
@@ -17,7 +17,7 @@ func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -17,7 +17,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef5.go
+++ b/internal/stagef5.go
@@ -17,7 +17,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}
@@ -133,6 +133,9 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 			},
 		},
 	}
+
+	// Byte to Byte comparison for RecordBatches
+	// Wire up ByteDiffVisualizer
 
 	return assertions.NewFetchResponseAssertion(*responseBody, expectedFetchResponse, logger).
 		AssertBody([]string{"ThrottleTimeMs", "ErrorCode"}).

--- a/internal/stagef6.go
+++ b/internal/stagef6.go
@@ -17,7 +17,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep1.go
+++ b/internal/stagep1.go
@@ -18,7 +18,7 @@ func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.Test
 
 	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -19,7 +19,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 
 	quietLogger := logger.GetQuietLogger("")
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger)
+	err := serializer.GenerateLogDirs(quietLogger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep3.go
+++ b/internal/stagep3.go
@@ -17,7 +17,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep4.go
+++ b/internal/stagep4.go
@@ -17,7 +17,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}
 
 	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger)
+	err := serializer.GenerateLogDirs(logger, true)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -17,7 +17,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 
 	logger := stageHarness.Logger
-	serializer.GenerateLogDirs(logger)
+	serializer.GenerateLogDirs(logger, true)
 
 	correlationId := getRandomCorrelationId()
 

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -61,11 +61,11 @@ func normalizeTesterOutput(testerOutput []byte) []byte {
 		"UUID":                   {regexp.MustCompile(`✓ Topic UUID: [0-9]{8}-[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{12}`)},
 		"value_length":           {regexp.MustCompile(`- .value_length \([0-9]{1,}\)`)},
 		"value":                  {regexp.MustCompile(`- .value \("[A-Za-z0-9 !]{1,}"\)`)},
-		"name":                   {regexp.MustCompile(`- .name \([A-Za-z]{1,}\)`)},
+		"name":                   {regexp.MustCompile(`- .name \([A-Za-z -]{1,}\)`)},
 		"topic_name":             {regexp.MustCompile(`- .topic_name \([A-Za-z0-9 ]{1,}\)`)},
 		"next_cursor":            {regexp.MustCompile(`- .next_cursor \(\{[A-Za-z0-9 ]{1,}\}\)`)},
 		"Messages":               {regexp.MustCompile(`✓ Messages: \["[A-Za-z !]{1,}"\]`)},
-		"Topic Name":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic Name: [A-Za-z]{3,}`)},
+		"Topic Name":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic Name: [A-Za-z -]{3,}`)},
 		"Topic UUID":             {regexp.MustCompile(`✓ TopicResponse\[[0-9]{1,}\] Topic UUID: [0-9 -]{1,}`)},
 	}
 

--- a/internal/test_helpers/fixtures/base/pass
+++ b/internal/test_helpers/fixtures/base/pass
@@ -2,21 +2,6 @@ Debug = true
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: pv1[0m
 [33m[stage-5] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-5] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-5] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-5] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-5] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 177586623)[0m
@@ -387,21 +372,6 @@ Debug = true
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: nc5[0m
 [33m[stage-4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-4] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-4] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-4] [0m[94mSending "ApiVersions" (version: 15281) request (Correlation id: 1616512461)[0m
@@ -431,21 +401,6 @@ Debug = true
 
 [33m[stage-3] [0m[94mRunning tests for Stage #3: wa6[0m
 [33m[stage-3] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-3] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-3] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-3] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 1698452642)[0m
@@ -505,21 +460,6 @@ Debug = true
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: nv3[0m
 [33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-2] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-2] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-2] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 7)[0m
@@ -579,21 +519,6 @@ Debug = true
 
 [33m[stage-1] [0m[94mRunning tests for Stage #1: vi6[0m
 [33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-1] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[94mConnecting to port 9092...[0m
 [33m[stage-1] [0m[36mConnection successful[0m
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/concurrent_stages/pass
+++ b/internal/test_helpers/fixtures/concurrent_stages/pass
@@ -2,21 +2,6 @@ Debug = true
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: nh4[0m
 [33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-2] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-2] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-2] [0m[94mSending request 1 of 2: "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
@@ -751,21 +736,6 @@ Debug = true
 
 [33m[stage-1] [0m[94mRunning tests for Stage #1: sk0[0m
 [33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-1] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-1/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-1] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m

--- a/internal/test_helpers/fixtures/describe_topic_partitions/pass
+++ b/internal/test_helpers/fixtures/describe_topic_partitions/pass
@@ -383,14 +383,14 @@ Debug = true
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-4] [0m[36m0000 | 00 00 00 31 00 4b 00 00 60 5a 05 cd 00 0c 6b 61 | ...1.K..`Z....ka[0m
 [33m[stage-4] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 12 75 6e 6b | fka-tester...unk[0m
-[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 73 61 7a 00 00 | nown-topic-saz..[0m
+[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 70 61 78 00 00 | nown-topic-pax..[0m
 [33m[stage-4] [0m[36m0030 | 00 00 01 ff 00                                  | .....[0m
 [33m[stage-4] [0m[36m[0m
 [33m[stage-4] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-4] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 02 00 03 12 75 6e 6b | `Z...........unk[0m
-[33m[stage-4] [0m[36m0010 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 73 61 7a 00 00 | nown-topic-saz..[0m
+[33m[stage-4] [0m[36m0010 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 70 61 78 00 00 | nown-topic-pax..[0m
 [33m[stage-4] [0m[36m0020 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 | ................[0m
 [33m[stage-4] [0m[36m0030 | 00 00 0d f8 00 ff 00                            | .......[0m
 [33m[stage-4] [0m[36m[0m
@@ -402,7 +402,7 @@ Debug = true
 [33m[stage-4] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-4] [Decoder] [0m[36m    - .error_code (3)[0m
-[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic-saz)[0m
+[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic-pax)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000000000)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .num_partitions (0)[0m
@@ -413,7 +413,7 @@ Debug = true
 [33m[stage-4] [0m[92m✓ Correlation ID: 1616512461[0m
 [33m[stage-4] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Error code: 3[0m
-[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic-saz[0m
+[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic-pax[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000000000[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 [33m[stage-4] [0m[36mTerminating program[0m
@@ -425,15 +425,7 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -443,14 +435,14 @@ Debug = true
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-3] [0m[36m0000 | 00 00 00 23 00 4b 00 00 05 c3 b0 2a 00 0c 6b 61 | ...#.K.....*..ka[0m
-[33m[stage-3] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 70 61 78 | fka-tester...pax[0m
+[33m[stage-3] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 62 61 72 | fka-tester...bar[0m
 [33m[stage-3] [0m[36m0020 | 00 00 00 00 01 ff 00                            | .......[0m
 [33m[stage-3] [0m[36m[0m
 [33m[stage-3] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 02 00 00 04 70 61 78 | ...*.........pax[0m
-[33m[stage-3] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 45 | ......@........E[0m
+[33m[stage-3] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 02 00 00 04 62 61 72 | ...*.........bar[0m
+[33m[stage-3] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 69 | ......@........i[0m
 [33m[stage-3] [0m[36m0020 | 00 02 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0040 | 0d f8 00 ff 00                                  | .....[0m
@@ -463,8 +455,8 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-3] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m    - .name (pax)[0m
-[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000045)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .name (bar)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000069)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -485,8 +477,8 @@ Debug = true
 [33m[stage-3] [0m[92m✓ Correlation ID: 96710698[0m
 [33m[stage-3] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-3] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic Name: pax[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000045[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000069[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 [33m[stage-3] [0m[36mTerminating program[0m
 [33m[stage-3] [0m[36mProgram terminated successfully[0m
@@ -497,15 +489,7 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -515,14 +499,14 @@ Debug = true
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-2] [0m[36m0000 | 00 00 00 23 00 4b 00 00 0f 2e 14 fa 00 0c 6b 61 | ...#.K........ka[0m
-[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 71 75 7a | fka-tester...quz[0m
+[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 66 6f 6f | fka-tester...foo[0m
 [33m[stage-2] [0m[36m0020 | 00 00 00 00 02 ff 00                            | .......[0m
 [33m[stage-2] [0m[36m[0m
 [33m[stage-2] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 02 00 00 04 71 75 7a | .............quz[0m
-[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 11 | ......@.........[0m
+[33m[stage-2] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 02 00 00 04 66 6f 6f | .............foo[0m
+[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 44 | ......@........D[0m
 [33m[stage-2] [0m[36m0020 | 00 03 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 01 00 00 00 01 00 00 00 00 02 00 00 00 | ................[0m
@@ -537,8 +521,8 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-2] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .name (quz)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000011)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .name (foo)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000044)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -570,8 +554,8 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: quz[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000011[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: foo[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000044[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m
@@ -586,15 +570,7 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -604,23 +580,23 @@ Debug = true
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-1] [0m[36m0000 | 00 00 00 2d 00 4b 00 00 70 d8 81 15 00 0c 6b 61 | ...-.K..p.....ka[0m
-[33m[stage-1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 04 04 70 61 78 | fka-tester...pax[0m
-[33m[stage-1] [0m[36m0020 | 00 04 70 61 7a 00 04 71 75 7a 00 00 00 00 04 ff | ..paz..quz......[0m
+[33m[stage-1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 04 04 62 61 72 | fka-tester...bar[0m
+[33m[stage-1] [0m[36m0020 | 00 04 62 61 7a 00 04 66 6f 6f 00 00 00 00 04 ff | ..baz..foo......[0m
 [33m[stage-1] [0m[36m0030 | 00                                              | .[0m
 [33m[stage-1] [0m[36m[0m
 [33m[stage-1] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 70 d8 81 15 00 00 00 00 00 04 00 00 04 70 61 78 | p............pax[0m
-[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 45 | ......@........E[0m
+[33m[stage-1] [0m[36m0000 | 70 d8 81 15 00 00 00 00 00 04 00 00 04 62 61 72 | p............bar[0m
+[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 69 | ......@........i[0m
 [33m[stage-1] [0m[36m0020 | 00 02 00 00 00 00 00 00 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0030 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0040 | 0d f8 00 00 00 04 70 61 7a 00 00 00 00 00 00 40 | ......paz......@[0m
-[33m[stage-1] [0m[36m0050 | 00 80 00 00 00 00 00 00 58 00 02 00 00 00 00 00 | ........X.......[0m
+[33m[stage-1] [0m[36m0040 | 0d f8 00 00 00 04 62 61 7a 00 00 00 00 00 00 40 | ......baz......@[0m
+[33m[stage-1] [0m[36m0050 | 00 80 00 00 00 00 00 00 53 00 02 00 00 00 00 00 | ........S.......[0m
 [33m[stage-1] [0m[36m0060 | 00 00 00 00 01 00 00 00 00 02 00 00 00 01 02 00 | ................[0m
-[33m[stage-1] [0m[36m0070 | 00 00 01 01 01 01 00 00 00 0d f8 00 00 00 04 71 | ...............q[0m
-[33m[stage-1] [0m[36m0080 | 75 7a 00 00 00 00 00 00 40 00 80 00 00 00 00 00 | uz......@.......[0m
-[33m[stage-1] [0m[36m0090 | 00 11 00 03 00 00 00 00 00 00 00 00 00 01 00 00 | ................[0m
+[33m[stage-1] [0m[36m0070 | 00 00 01 01 01 01 00 00 00 0d f8 00 00 00 04 66 | ...............f[0m
+[33m[stage-1] [0m[36m0080 | 6f 6f 00 00 00 00 00 00 40 00 80 00 00 00 00 00 | oo......@.......[0m
+[33m[stage-1] [0m[36m0090 | 00 44 00 03 00 00 00 00 00 00 00 00 00 01 00 00 | .D..............[0m
 [33m[stage-1] [0m[36m00a0 | 00 00 02 00 00 00 01 02 00 00 00 01 01 01 01 00 | ................[0m
 [33m[stage-1] [0m[36m00b0 | 00 00 00 00 00 01 00 00 00 01 00 00 00 00 02 00 | ................[0m
 [33m[stage-1] [0m[36m00c0 | 00 00 01 02 00 00 00 01 01 01 01 00 00 00 0d f8 | ................[0m
@@ -634,8 +610,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m  - .topic.length (3)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (pax)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000045)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (bar)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000069)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -653,8 +629,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[1][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (paz)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (baz)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000053)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -672,8 +648,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[2][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (quz)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000011)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (foo)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000044)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -705,18 +681,18 @@ Debug = true
 [33m[stage-1] [0m[92m✓ Correlation ID: 1893237013[0m
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic Name: pax[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000045[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000069[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[1] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: paz[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: baz[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000053[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[2] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: quz[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000011[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: foo[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000044[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m

--- a/internal/test_helpers/fixtures/fetch/pass
+++ b/internal/test_helpers/fixtures/fetch/pass
@@ -2,21 +2,6 @@ Debug = true
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: gs0[0m
 [33m[stage-4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
-[33m[stage-4] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-4] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 177586623)[0m
@@ -61,7 +46,7 @@ Debug = true
 [33m[stage-4] [0m[36m01c0 | 2e 76 65 72 73 69 6f 6e 00 00 00 01 00 0e 6b 72 | .version......kr[0m
 [33m[stage-4] [0m[36m01d0 | 61 66 74 2e 76 65 72 73 69 6f 6e 00 00 00 01 00 | aft.version.....[0m
 [33m[stage-4] [0m[36m01e0 | 11 6d 65 74 61 64 61 74 61 2e 76 65 72 73 69 6f | .metadata.versio[0m
-[33m[stage-4] [0m[36m01f0 | 6e 00 01 00 16 00 01 08 00 00 00 00 00 00 00 0b | n...............[0m
+[33m[stage-4] [0m[36m01f0 | 6e 00 01 00 16 00 01 08 00 00 00 00 00 00 00 0c | n...............[0m
 [33m[stage-4] [0m[36m0200 | 02 17 02 11 6d 65 74 61 64 61 74 61 2e 76 65 72 | ....metadata.ver[0m
 [33m[stage-4] [0m[36m0210 | 73 69 6f 6e 00 14 00 14 00                      | sion.....[0m
 [33m[stage-4] [0m[36m[0m
@@ -394,15 +379,15 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -419,7 +404,7 @@ Debug = true
 [33m[stage-3] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 0f 58 2f fb 01 | `Z..........X/..[0m
+[33m[stage-3] [0m[36m0000 | 60 5a 05 cd 00 00 00 00 00 00 00 08 09 e5 58 01 | `Z............X.[0m
 [33m[stage-3] [0m[36m0010 | 00                                              | .[0m
 [33m[stage-3] [0m[36m[0m
 [33m[stage-3] [Decoder] [0m[36m- .ResponseHeader[0m
@@ -428,7 +413,7 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-3] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m  - .session_id (257437691)[0m
+[33m[stage-3] [Decoder] [0m[36m  - .session_id (134866264)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .num_responses (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-3] [0m[92m✓ Correlation ID: 1616512461[0m
@@ -445,15 +430,15 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -465,7 +450,7 @@ Debug = true
 [33m[stage-2] [0m[36m0000 | 00 00 00 60 00 01 00 10 05 c3 b0 2a 00 09 6b 61 | ...`.......*..ka[0m
 [33m[stage-2] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-2] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 42 08 02 00 | ............B...[0m
+[33m[stage-2] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 15 33 02 00 | .............3..[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-2] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -473,8 +458,8 @@ Debug = true
 [33m[stage-2] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 0f 88 6e 28 02 | ...*.........n(.[0m
-[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 42 08 | ..............B.[0m
+[33m[stage-2] [0m[36m0000 | 05 c3 b0 2a 00 00 00 00 00 00 00 00 d3 31 b9 02 | ...*.........1..[0m
+[33m[stage-2] [0m[36m0010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 15 33 | ...............3[0m
 [33m[stage-2] [0m[36m0020 | 02 00 00 00 00 00 64 ff ff ff ff ff ff ff ff ff | ......d.........[0m
 [33m[stage-2] [0m[36m0030 | ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff 01 | ................[0m
 [33m[stage-2] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
@@ -485,10 +470,10 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-2] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m  - .session_id (260599336)[0m
+[33m[stage-2] [Decoder] [0m[36m  - .session_id (13840825)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000004208)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000001533)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-2] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -505,7 +490,7 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 96710698[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000004208[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000001533[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 100 (UNKNOWN_TOPIC_ID)[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m    ✓ RecordBatches: [][0m
@@ -519,15 +504,15 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/paz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/quz-1/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
@@ -539,7 +524,7 @@ Debug = true
 [33m[stage-1] [0m[36m0000 | 00 00 00 60 00 01 00 10 0f 2e 14 fa 00 09 6b 61 | ...`..........ka[0m
 [33m[stage-1] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-1] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 58 02 00 | ....@........X..[0m
+[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 53 02 00 | ....@........S..[0m
 [33m[stage-1] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-1] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -547,8 +532,8 @@ Debug = true
 [33m[stage-1] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 0a a5 d9 23 02 | ..............#.[0m
-[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 58 | ......@........X[0m
+[33m[stage-1] [0m[36m0000 | 0f 2e 14 fa 00 00 00 00 00 00 00 0e ec a5 45 02 | ..............E.[0m
+[33m[stage-1] [0m[36m0010 | 00 00 00 00 00 00 40 00 80 00 00 00 00 00 00 53 | ......@........S[0m
 [33m[stage-1] [0m[36m0020 | 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0040 | ff ff ff ff 01 00 00 00                         | ........[0m
@@ -559,10 +544,10 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-1] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m  - .session_id (178641187)[0m
+[33m[stage-1] [Decoder] [0m[36m  - .session_id (250389829)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000058)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000053)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-1] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -579,7 +564,7 @@ Debug = true
 [33m[stage-1] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000058[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000053[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m    ✓ RecordBatches: [][0m

--- a/protocol/api/spec.yml
+++ b/protocol/api/spec.yml
@@ -347,3 +347,5 @@ data:
   - 0x01 
   - 0x00 # Number of Headers (1 byte, 0x00 in hex, 0 in decimal) 
   // ToDo Do paylaods have headers or tagged fields ?
+  // ToDo: versions of payloads ?
+  // ToDo: indented values for data structures, like compact arrays

--- a/protocol/serializer/generate_log_dir.go
+++ b/protocol/serializer/generate_log_dir.go
@@ -9,7 +9,10 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-func GenerateLogDirs(logger *logger.Logger) error {
+// GenerateLogDirs generates the log directories and files for the test cases.
+// If onlyClusterMetadata is true, only the cluster metadata will be generated.
+// .log files & partition metadata files inside the topic directories will not be created.
+func GenerateLogDirs(logger *logger.Logger, onlyClusterMetadata bool) error {
 	// Topic1 -> Message1 (Partition=1)
 	// Topic2 -> None (Partition=1)
 	// Topic3 -> Message2, Message3 (Partition=2)
@@ -85,24 +88,26 @@ func GenerateLogDirs(logger *logger.Logger) error {
 		return err
 	}
 
-	err = writePartitionMetadata(topic1MetadataPath, 0, topic1ID, logger)
-	if err != nil {
-		return err
-	}
+	if !onlyClusterMetadata {
+		err = writePartitionMetadata(topic1MetadataPath, 0, topic1ID, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writePartitionMetadata(topic2MetadataPath, 0, topic2ID, logger)
-	if err != nil {
-		return err
-	}
+		err = writePartitionMetadata(topic2MetadataPath, 0, topic2ID, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writePartitionMetadata(topic3Partition1MetadataPath, 0, topic3ID, logger)
-	if err != nil {
-		return err
-	}
+		err = writePartitionMetadata(topic3Partition1MetadataPath, 0, topic3ID, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writePartitionMetadata(topic3Partition2MetadataPath, 0, topic3ID, logger)
-	if err != nil {
-		return err
+		err = writePartitionMetadata(topic3Partition2MetadataPath, 0, topic3ID, logger)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = writePartitionMetadata(clusterMetadataMetadataPath, 0, clusterMetadataTopicID, logger)
@@ -110,24 +115,26 @@ func GenerateLogDirs(logger *logger.Logger) error {
 		return err
 	}
 
-	err = writeTopicData(topic1DataFilePath, []string{common.MESSAGE1}, logger)
-	if err != nil {
-		return err
-	}
+	if !onlyClusterMetadata {
+		err = writeTopicData(topic1DataFilePath, []string{common.MESSAGE1}, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writeTopicData(topic2DataFilePath, []string{}, logger)
-	if err != nil {
-		return err
-	}
+		err = writeTopicData(topic2DataFilePath, []string{}, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writeTopicData(topic3Partition1DataFilePath, []string{common.MESSAGE2, common.MESSAGE3}, logger)
-	if err != nil {
-		return err
-	}
+		err = writeTopicData(topic3Partition1DataFilePath, []string{common.MESSAGE2, common.MESSAGE3}, logger)
+		if err != nil {
+			return err
+		}
 
-	err = writeTopicData(topic3Partition2DataFilePath, []string{}, logger)
-	if err != nil {
-		return err
+		err = writeTopicData(topic3Partition2DataFilePath, []string{}, logger)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = writeClusterMetadata(clusterMetadataDataFilePath, topic1Name, topic1UUID, topic2Name, topic2UUID, topic3Name, topic3UUID, directoryUUID, logger)


### PR DESCRIPTION
This pull request refactors the `generateLogDirs` method in the `serializer` package to accept a new boolean parameter that determines whether to skip writing topic directory data. This parameter allows for more flexibility when calling the method from different stages. The changes are implemented in multiple test cases, ensuring that the new parameter is properly used throughout the codebase.