### PR TITLE
Introduce Response struct to improve broker response handling

### DIFF
--- a/internal/stage5.go
+++ b/internal/stage5.go
@@ -54,9 +54,9 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response, 3, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagec1.go
+++ b/internal/stagec1.go
@@ -56,9 +56,9 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		if err != nil {
 			return err
 		}
-		logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+		logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response, 3, logger)
+		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
 		if err != nil {
 			return err
 		}

--- a/internal/stagec2.go
+++ b/internal/stagec2.go
@@ -71,9 +71,9 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		if err != nil {
 			return err
 		}
-		logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+		logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response, 3, logger)
+		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
 		if err != nil {
 			return err
 		}

--- a/internal/stagef1.go
+++ b/internal/stagef1.go
@@ -53,9 +53,9 @@ func testAPIVersionwFetchKey(stageHarness *test_case_harness.TestCaseHarness) er
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response, 3, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef2.go
+++ b/internal/stagef2.go
@@ -57,9 +57,9 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef3.go
+++ b/internal/stagef3.go
@@ -74,9 +74,9 @@ func testFetchWithUnkownTopicID(stageHarness *test_case_harness.TestCaseHarness)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -72,9 +72,9 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef5.go
+++ b/internal/stagef5.go
@@ -72,9 +72,9 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagef6.go
+++ b/internal/stagef6.go
@@ -72,9 +72,9 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response, 16, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep1.go
+++ b/internal/stagep1.go
@@ -53,9 +53,9 @@ func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.Test
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response, 3, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -57,9 +57,9 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep3.go
+++ b/internal/stagep3.go
@@ -55,9 +55,9 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep4.go
+++ b/internal/stagep4.go
@@ -55,9 +55,9 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stagep5.go
+++ b/internal/stagep5.go
@@ -60,9 +60,9 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response))
+	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
 	if err != nil {
 		return err
 	}

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -108,7 +108,7 @@ func ApiVersions(b *protocol.Broker, requestBody *ApiVersionsRequestBody) (*ApiV
 		return nil, err
 	}
 
-	_, apiVersionsResponse, err := DecodeApiVersionsHeaderAndResponse(response, requestBody.Version, logger.GetLogger(true, ""))
+	_, apiVersionsResponse, err := DecodeApiVersionsHeaderAndResponse(response.Payload, requestBody.Version, logger.GetLogger(true, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -109,7 +109,7 @@ func DescribeTopicPartitions(b *protocol.Broker) (*DescribeTopicPartitionsRespon
 		return nil, err
 	}
 
-	_, DescribeTopicPartitionsResponse, err := DecodeDescribeTopicPartitionsHeaderAndResponse(response, logger.GetLogger(true, ""))
+	_, DescribeTopicPartitionsResponse, err := DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger.GetLogger(true, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -2,6 +2,7 @@ package kafkaapi
 
 import (
 	"fmt"
+
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 
@@ -125,9 +126,9 @@ func fetch(b *protocol.Broker, requestBody *FetchRequestBody, logger *logger.Log
 		return nil, err
 	}
 
-	protocol.PrintHexdump(response)
+	protocol.PrintHexdump(response.RawBytes)
 
-	_, fetchResponse, err := DecodeFetchHeaderAndResponse(response, 16, logger)
+	_, fetchResponse, err := DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR introduces a new `Response` struct to better handle broker responses, separating raw bytes from payload data. This change improves response handling clarity and consistency across the codebase.

### Changes
- Added new `Response` struct with `RawBytes` and `Payload` fields
- Modified `Broker.SendAndReceive()` and `Broker.Receive()` to return `Response` instead of raw bytes
- Updated all API calls to use the new Response struct fields:
  - `response.RawBytes` for hexdump logging
  - `response.Payload` for decoding responses

### Impact
- More explicit separation between raw response bytes and actual payload data
- Improved consistency in response handling across different API endpoints
- Better maintainability by centralizing response handling logic

### Testing
All existing tests have been updated to work with the new Response struct.