### PR TITLE
Finish generating LogDirectory before booting up any executable

### DIFF
--- a/internal/stage1.go
+++ b/internal/stage1.go
@@ -10,14 +10,13 @@ import (
 
 func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
+	if err != nil {
 		return err
 	}
 
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
-	if err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
 
@@ -26,5 +25,5 @@ func testBindToPort(stageHarness *test_case_harness.TestCaseHarness) error {
 		Retries: 15,
 	}
 
-	return bindTestCase.Run(b, logger)
+	return bindTestCase.Run(b, stageLogger)
 }

--- a/internal/stage3.go
+++ b/internal/stage3.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"github.com/codecrafters-io/tester-utils/logger"
 
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 
@@ -10,28 +11,28 @@ import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
 func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
 	if err != nil {
 		return err
 	}
 
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
-	defer broker.Close()
+
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	correlationId := getRandomCorrelationId()
 
@@ -50,8 +51,8 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	logger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
 
 	err = broker.Send(message)
 	if err != nil {
@@ -61,13 +62,13 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
 
 	decoder := realdecoder.RealDecoder{}
 	decoder.Init(response)
-	logger.UpdateSecondaryPrefix("Decoder")
+	stageLogger.UpdateSecondaryPrefix("Decoder")
 
-	logger.Debugf("- .Response")
+	stageLogger.Debugf("- .Response")
 	messageLength, err := decoder.GetInt32()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -76,9 +77,9 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 		}
 		return err
 	}
-	protocol.LogWithIndentation(logger, 1, "- .message_length (%d)", messageLength)
+	protocol.LogWithIndentation(stageLogger, 1, "- .message_length (%d)", messageLength)
 
-	logger.Debugf("- .ResponseHeader")
+	stageLogger.Debugf("- .ResponseHeader")
 	responseCorrelationId, err := decoder.GetInt32()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -87,14 +88,14 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 		}
 		return err
 	}
-	protocol.LogWithIndentation(logger, 1, "- .correlation_id (%d)", responseCorrelationId)
-	logger.ResetSecondaryPrefix()
+	protocol.LogWithIndentation(stageLogger, 1, "- .correlation_id (%d)", responseCorrelationId)
+	stageLogger.ResetSecondaryPrefix()
 
 	if responseCorrelationId != correlationId {
 		return fmt.Errorf("Expected Correlation ID to be %v, got %v", correlationId, responseCorrelationId)
 	}
 
-	logger.Successf("✓ Correlation ID: %v", responseCorrelationId)
+	stageLogger.Successf("✓ Correlation ID: %v", responseCorrelationId)
 
 	return nil
 }

--- a/internal/stage5.go
+++ b/internal/stage5.go
@@ -13,24 +13,25 @@ import (
 
 func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
+	if err != nil {
 		return err
 	}
 
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
-	if err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
 
 	correlationId := getRandomCorrelationId()
 
 	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer broker.Close()
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
 		Header: kafkaapi.RequestHeader{
@@ -47,16 +48,16 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	logger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {
 		return err
 	}
@@ -64,17 +65,17 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	if responseHeader.CorrelationId != correlationId {
 		return fmt.Errorf("Expected Correlation ID to be %v, got %v", correlationId, responseHeader.CorrelationId)
 	}
-	logger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
+	stageLogger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
 
 	if responseBody.ErrorCode != 0 {
 		return fmt.Errorf("Expected Error code to be 0, got %v", responseBody.ErrorCode)
 	}
-	logger.Successf("✓ Error code: 0 (NO_ERROR)")
+	stageLogger.Successf("✓ Error code: 0 (NO_ERROR)")
 
 	if len(responseBody.ApiKeys) < 1 {
 		return fmt.Errorf("Expected API keys array to be non-empty")
 	}
-	logger.Successf("✓ API keys array is non-empty")
+	stageLogger.Successf("✓ API keys array is non-empty")
 
 	foundAPIKey := false
 	MAX_VERSION := int16(4)
@@ -82,7 +83,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		if apiVersionKey.ApiKey == 18 {
 			foundAPIKey = true
 			if apiVersionKey.MaxVersion >= MAX_VERSION {
-				logger.Successf("✓ API version %v is supported for API_VERSIONS", MAX_VERSION)
+				stageLogger.Successf("✓ API version %v is supported for API_VERSIONS", MAX_VERSION)
 			} else {
 				return fmt.Errorf("Expected API version %v to be supported for API_VERSIONS, got %v", MAX_VERSION, apiVersionKey.MaxVersion)
 			}

--- a/internal/stagec1.go
+++ b/internal/stagec1.go
@@ -2,34 +2,35 @@ package internal
 
 import (
 	"fmt"
+	"github.com/codecrafters-io/tester-utils/logger"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
 func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
 	if err != nil {
 		return err
 	}
 
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
-	defer broker.Close()
+
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	requestCount := random.RandomInt(2, 5)
 	for i := 0; i < requestCount; i++ {
@@ -49,16 +50,16 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		}
 
 		message := kafkaapi.EncodeApiVersionsRequest(&request)
-		logger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		logger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
+		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
 
 		response, err := broker.SendAndReceive(message)
 		if err != nil {
 			return err
 		}
-		logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
+		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {
 			return err
 		}
@@ -66,17 +67,17 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		if responseHeader.CorrelationId != correlationId {
 			return fmt.Errorf("Expected Correlation ID to be %v, got %v", correlationId, responseHeader.CorrelationId)
 		}
-		logger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
+		stageLogger.Successf("✓ Correlation ID: %v", responseHeader.CorrelationId)
 
 		if responseBody.ErrorCode != 0 {
 			return fmt.Errorf("Expected Error code to be 0, got %v", responseBody.ErrorCode)
 		}
-		logger.Successf("✓ Error code: 0 (NO_ERROR)")
+		stageLogger.Successf("✓ Error code: 0 (NO_ERROR)")
 
 		if len(responseBody.ApiKeys) < 1 {
 			return fmt.Errorf("Expected API keys array to include atleast 1 key (API_VERSIONS), got %v", len(responseBody.ApiKeys))
 		}
-		logger.Successf("✓ API keys array is non-empty")
+		stageLogger.Successf("✓ API keys array is non-empty")
 
 		foundAPIKey := false
 		MAX_VERSION_APIVERSION := int16(4)
@@ -84,7 +85,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			if apiVersionKey.ApiKey == 18 {
 				foundAPIKey = true
 				if apiVersionKey.MaxVersion >= MAX_VERSION_APIVERSION {
-					logger.Successf("✓ API version %v is supported for API_VERSIONS", MAX_VERSION_APIVERSION)
+					stageLogger.Successf("✓ API version %v is supported for API_VERSIONS", MAX_VERSION_APIVERSION)
 				} else {
 					return fmt.Errorf("Expected API version %v to be supported for API_VERSIONS, got %v", MAX_VERSION_APIVERSION, apiVersionKey.MaxVersion)
 				}
@@ -95,7 +96,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			return fmt.Errorf("Expected APIVersionsResponseKey to be present for API key 18 (API_VERSIONS)")
 		}
 
-		logger.Successf("✓ Test %v of %v: Passed", i+1, requestCount)
+		stageLogger.Successf("✓ Test %v of %v: Passed", i+1, requestCount)
 	}
 
 	return nil

--- a/internal/stagef4.go
+++ b/internal/stagef4.go
@@ -12,23 +12,24 @@ import (
 
 func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
+	if err := b.Run(); err != nil {
+		return err
+	}
 
+	correlationId := getRandomCorrelationId()
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer broker.Close()
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.FetchRequest{
 		Header: kafkaapi.RequestHeader{

--- a/internal/stagef5.go
+++ b/internal/stagef5.go
@@ -12,23 +12,24 @@ import (
 
 func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
+	if err := b.Run(); err != nil {
+		return err
+	}
 
+	correlationId := getRandomCorrelationId()
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer broker.Close()
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.FetchRequest{
 		Header: kafkaapi.RequestHeader{

--- a/internal/stagef6.go
+++ b/internal/stagef6.go
@@ -12,23 +12,24 @@ import (
 
 func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
 	logger := stageHarness.Logger
 	err := serializer.GenerateLogDirs(logger, false)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
+	if err := b.Run(); err != nil {
+		return err
+	}
 
+	correlationId := getRandomCorrelationId()
 	broker := protocol.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer broker.Close()
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.FetchRequest{
 		Header: kafkaapi.RequestHeader{

--- a/internal/stagep1.go
+++ b/internal/stagep1.go
@@ -10,26 +10,26 @@ import (
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
-func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.TestCaseHarness) error {
+func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
-
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
-	defer broker.Close()
+
+	correlationId := getRandomCorrelationId()
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
 		Header: kafkaapi.RequestHeader{
@@ -46,16 +46,16 @@ func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.Test
 	}
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	logger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.Test
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}
 
@@ -84,7 +84,7 @@ func testAPIVersionwDescribeTopicPartitions(stageHarness *test_case_harness.Test
 		},
 	}
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, logger); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
 		return err
 	}
 

--- a/internal/stagep2.go
+++ b/internal/stagep2.go
@@ -13,24 +13,24 @@ import (
 
 func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
-	quietLogger := logger.GetQuietLogger("")
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(quietLogger, true)
+	err := serializer.GenerateLogDirs(logger.GetQuietLogger(""), true)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
-
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	stageLogger := stageHarness.Logger
+	if err := b.Run(); err != nil {
 		return err
 	}
-	defer broker.Close()
+
+	correlationId := getRandomCorrelationId()
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
@@ -50,16 +50,16 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
 		Run()

--- a/internal/stagep3.go
+++ b/internal/stagep3.go
@@ -12,23 +12,24 @@ import (
 
 func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.TestCaseHarness) error {
 	b := kafka_executable.NewKafkaExecutable(stageHarness)
-	if err := b.Run(); err != nil {
-		return err
-	}
-
-	logger := stageHarness.Logger
-	err := serializer.GenerateLogDirs(logger, true)
+	stageLogger := stageHarness.Logger
+	err := serializer.GenerateLogDirs(stageLogger, true)
 	if err != nil {
 		return err
 	}
 
-	correlationId := getRandomCorrelationId()
-
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.ConnectWithRetries(b, logger); err != nil {
+	if err := b.Run(); err != nil {
 		return err
 	}
-	defer broker.Close()
+
+	correlationId := getRandomCorrelationId()
+	broker := protocol.NewBroker("localhost:9092")
+	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer func(broker *protocol.Broker) {
+		_ = broker.Close()
+	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
 		Header: kafkaapi.RequestHeader{
@@ -48,16 +49,16 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	logger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
 
-	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger)
+	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {
 		return err
 	}
@@ -65,7 +66,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}
 
@@ -92,7 +93,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, logger).
+	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody([]string{"ThrottleTimeMs"}).
 		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
 		Run()

--- a/internal/test_helpers/fixtures/describe_topic_partitions/pass
+++ b/internal/test_helpers/fixtures/describe_topic_partitions/pass
@@ -383,15 +383,15 @@ Debug = true
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-4] [0m[36m0000 | 00 00 00 31 00 4b 00 00 60 5a 05 cd 00 0c 6b 61 | ...1.K..`Z....ka[0m
 [33m[stage-4] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 12 75 6e 6b | fka-tester...unk[0m
-[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 70 61 7a 00 00 | nown-topic-paz..[0m
+[33m[stage-4] [0m[36m0020 | 6e 6f 77 6e 2d 74 6f 70 69 63 2d 71 75 7a 00 00 | nown-topic-quz..[0m
 [33m[stage-4] [0m[36m0030 | 00 00 01 ff 00                                  | .....[0m
 [33m[stage-4] [0m[36m[0m
 [33m[stage-4] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-4] [0m[36m0000 | 00 00 00 37 60 5a 05 cd 00 00 00 00 00 02 00 03 | ...7`Z..........[0m
-[33m[stage-4] [0m[36m0010 | 12 75 6e 6b 6e 6f 77 6e 2d 74 6f 70 69 63 2d 70 | .unknown-topic-p[0m
-[33m[stage-4] [0m[36m0020 | 61 7a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | az..............[0m
+[33m[stage-4] [0m[36m0010 | 12 75 6e 6b 6e 6f 77 6e 2d 74 6f 70 69 63 2d 71 | .unknown-topic-q[0m
+[33m[stage-4] [0m[36m0020 | 75 7a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | uz..............[0m
 [33m[stage-4] [0m[36m0030 | 00 00 00 01 00 00 0d f8 00 ff 00                | ...........[0m
 [33m[stage-4] [0m[36m[0m
 [33m[stage-4] [Decoder] [0m[36m- .ResponseHeader[0m
@@ -402,7 +402,7 @@ Debug = true
 [33m[stage-4] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-4] [Decoder] [0m[36m    - .error_code (3)[0m
-[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic-paz)[0m
+[33m[stage-4] [Decoder] [0m[36m    - .name (unknown-topic-quz)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000000000)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .num_partitions (0)[0m
@@ -413,14 +413,13 @@ Debug = true
 [33m[stage-4] [0m[92m✓ Correlation ID: 1616512461[0m
 [33m[stage-4] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Error code: 3[0m
-[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic-paz[0m
+[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic Name: unknown-topic-quz[0m
 [33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000000000[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 [33m[stage-4] [0m[36mTerminating program[0m
 [33m[stage-4] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-3] [0m[94mRunning tests for Stage #3: ea7[0m
-[33m[stage-3] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
@@ -428,6 +427,7 @@ Debug = true
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-3] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-3] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-3] [0m[94mSending "DescribeTopicPartitions" (version: 0) request (Correlation id: 96710698)[0m
@@ -443,7 +443,7 @@ Debug = true
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-3] [0m[36m0000 | 00 00 00 45 05 c3 b0 2a 00 00 00 00 00 02 00 00 | ...E...*........[0m
 [33m[stage-3] [0m[36m0010 | 04 62 61 72 00 00 00 00 00 00 40 00 80 00 00 00 | .bar......@.....[0m
-[33m[stage-3] [0m[36m0020 | 00 00 00 42 00 02 00 00 00 00 00 00 00 00 00 01 | ...B............[0m
+[33m[stage-3] [0m[36m0020 | 00 00 00 20 00 02 00 00 00 00 00 00 00 00 00 01 | ... ............[0m
 [33m[stage-3] [0m[36m0030 | 00 00 00 00 02 00 00 00 01 02 00 00 00 01 01 01 | ................[0m
 [33m[stage-3] [0m[36m0040 | 01 00 00 00 0d f8 00 ff 00                      | .........[0m
 [33m[stage-3] [0m[36m[0m
@@ -456,7 +456,7 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-3] [Decoder] [0m[36m    - .error_code (0)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .name (bar)[0m
-[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000042)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000020)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -478,13 +478,12 @@ Debug = true
 [33m[stage-3] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-3] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
 [33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000042[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000020[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 [33m[stage-3] [0m[36mTerminating program[0m
 [33m[stage-3] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: ku4[0m
-[33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
@@ -492,6 +491,7 @@ Debug = true
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-2] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-2] [0m[94mSending "DescribeTopicPartitions" (version: 0) request (Correlation id: 254678266)[0m
@@ -499,15 +499,15 @@ Debug = true
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-2] [0m[36m0000 | 00 00 00 23 00 4b 00 00 0f 2e 14 fa 00 0c 6b 61 | ...#.K........ka[0m
-[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 66 6f 6f | fka-tester...foo[0m
+[33m[stage-2] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 02 04 70 61 78 | fka-tester...pax[0m
 [33m[stage-2] [0m[36m0020 | 00 00 00 00 02 ff 00                            | .......[0m
 [33m[stage-2] [0m[36m[0m
 [33m[stage-2] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-2] [0m[36m0000 | 00 00 00 61 0f 2e 14 fa 00 00 00 00 00 02 00 00 | ...a............[0m
-[33m[stage-2] [0m[36m0010 | 04 66 6f 6f 00 00 00 00 00 00 40 00 80 00 00 00 | .foo......@.....[0m
-[33m[stage-2] [0m[36m0020 | 00 00 00 32 00 03 00 00 00 00 00 00 00 00 00 01 | ...2............[0m
+[33m[stage-2] [0m[36m0010 | 04 70 61 78 00 00 00 00 00 00 40 00 80 00 00 00 | .pax......@.....[0m
+[33m[stage-2] [0m[36m0020 | 00 00 00 15 00 03 00 00 00 00 00 00 00 00 00 01 | ................[0m
 [33m[stage-2] [0m[36m0030 | 00 00 00 00 02 00 00 00 01 02 00 00 00 01 01 01 | ................[0m
 [33m[stage-2] [0m[36m0040 | 01 00 00 00 00 00 00 01 00 00 00 01 00 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0050 | 02 00 00 00 01 02 00 00 00 01 01 01 01 00 00 00 | ................[0m
@@ -521,8 +521,8 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m  - .topic.length (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-2] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .name (foo)[0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000032)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .name (pax)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000015)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -554,8 +554,8 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: foo[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000032[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic Name: pax[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000015[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m
@@ -565,7 +565,6 @@ Debug = true
 [33m[stage-2] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-1] [0m[94mRunning tests for Stage #1: wq2[0m
-[33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
@@ -573,6 +572,7 @@ Debug = true
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-1] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-1] [0m[94mSending "DescribeTopicPartitions" (version: 0) request (Correlation id: 1893237013)[0m
@@ -581,7 +581,7 @@ Debug = true
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-1] [0m[36m0000 | 00 00 00 2d 00 4b 00 00 70 d8 81 15 00 0c 6b 61 | ...-.K..p.....ka[0m
 [33m[stage-1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 04 04 62 61 72 | fka-tester...bar[0m
-[33m[stage-1] [0m[36m0020 | 00 04 62 61 7a 00 04 66 6f 6f 00 00 00 00 04 ff | ..baz..foo......[0m
+[33m[stage-1] [0m[36m0020 | 00 04 66 6f 6f 00 04 70 61 78 00 00 00 00 04 ff | ..foo..pax......[0m
 [33m[stage-1] [0m[36m0030 | 00                                              | .[0m
 [33m[stage-1] [0m[36m[0m
 [33m[stage-1] [0m[36mHexdump of received "DescribeTopicPartitions" response: [0m
@@ -589,14 +589,14 @@ Debug = true
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
 [33m[stage-1] [0m[36m0000 | 00 00 00 d3 70 d8 81 15 00 00 00 00 00 04 00 00 | ....p...........[0m
 [33m[stage-1] [0m[36m0010 | 04 62 61 72 00 00 00 00 00 00 40 00 80 00 00 00 | .bar......@.....[0m
-[33m[stage-1] [0m[36m0020 | 00 00 00 42 00 02 00 00 00 00 00 00 00 00 00 01 | ...B............[0m
+[33m[stage-1] [0m[36m0020 | 00 00 00 20 00 02 00 00 00 00 00 00 00 00 00 01 | ... ............[0m
 [33m[stage-1] [0m[36m0030 | 00 00 00 00 02 00 00 00 01 02 00 00 00 01 01 01 | ................[0m
-[33m[stage-1] [0m[36m0040 | 01 00 00 00 0d f8 00 00 00 04 62 61 7a 00 00 00 | ..........baz...[0m
-[33m[stage-1] [0m[36m0050 | 00 00 00 40 00 80 00 00 00 00 00 00 76 00 02 00 | ...@........v...[0m
+[33m[stage-1] [0m[36m0040 | 01 00 00 00 0d f8 00 00 00 04 66 6f 6f 00 00 00 | ..........foo...[0m
+[33m[stage-1] [0m[36m0050 | 00 00 00 40 00 80 00 00 00 00 00 00 96 00 02 00 | ...@............[0m
 [33m[stage-1] [0m[36m0060 | 00 00 00 00 00 00 00 00 01 00 00 00 00 02 00 00 | ................[0m
 [33m[stage-1] [0m[36m0070 | 00 01 02 00 00 00 01 01 01 01 00 00 00 0d f8 00 | ................[0m
-[33m[stage-1] [0m[36m0080 | 00 00 04 66 6f 6f 00 00 00 00 00 00 40 00 80 00 | ...foo......@...[0m
-[33m[stage-1] [0m[36m0090 | 00 00 00 00 00 32 00 03 00 00 00 00 00 00 00 00 | .....2..........[0m
+[33m[stage-1] [0m[36m0080 | 00 00 04 70 61 78 00 00 00 00 00 00 40 00 80 00 | ...pax......@...[0m
+[33m[stage-1] [0m[36m0090 | 00 00 00 00 00 15 00 03 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m00a0 | 00 01 00 00 00 00 02 00 00 00 01 02 00 00 00 01 | ................[0m
 [33m[stage-1] [0m[36m00b0 | 01 01 01 00 00 00 00 00 00 01 00 00 00 01 00 00 | ................[0m
 [33m[stage-1] [0m[36m00c0 | 00 00 02 00 00 00 01 02 00 00 00 01 01 01 01 00 | ................[0m
@@ -611,7 +611,7 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[0][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .name (bar)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000042)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000020)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -629,8 +629,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[1][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (baz)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000076)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (foo)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000096)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -648,8 +648,8 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .Topics[2][0m
 [33m[stage-1] [Decoder] [0m[36m    - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .name (foo)[0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000032)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .name (pax)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000015)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .is_internal (false)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (2)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .Partitions[0][0m
@@ -682,17 +682,17 @@ Debug = true
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic Name: bar[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000042[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000020[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[1] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: baz[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000076[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic Name: foo[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[1] Topic UUID: 00000000-0000-4000-8000-000000000096[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m  ✓ TopicResponse[2] Error code: 0[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: foo[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000032[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic Name: pax[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[2] Topic UUID: 00000000-0000-4000-8000-000000000015[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[1] Error code: 0[0m

--- a/internal/test_helpers/fixtures/fetch/pass
+++ b/internal/test_helpers/fixtures/fetch/pass
@@ -374,22 +374,22 @@ Debug = true
 [33m[stage-6] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-5] [0m[94mRunning tests for Stage #5: dh6[0m
-[33m[stage-5] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-5] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/partition.metadata[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/00000000000000000000.log[0m
 [33m[stage-5] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-5] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-5] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-5] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-5] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-5] [0m[94mSending "Fetch" (version: 16) request (Correlation id: 1616512461)[0m
@@ -404,8 +404,8 @@ Debug = true
 [33m[stage-5] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-5] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-5] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-5] [0m[36m0000 | 00 00 00 11 60 5a 05 cd 00 00 00 00 00 00 00 04 | ....`Z..........[0m
-[33m[stage-5] [0m[36m0010 | 0f a9 38 01 00                                  | ..8..[0m
+[33m[stage-5] [0m[36m0000 | 00 00 00 11 60 5a 05 cd 00 00 00 00 00 00 00 03 | ....`Z..........[0m
+[33m[stage-5] [0m[36m0010 | 30 d0 a4 01 00                                  | 0....[0m
 [33m[stage-5] [0m[36m[0m
 [33m[stage-5] [Decoder] [0m[36m- .ResponseHeader[0m
 [33m[stage-5] [Decoder] [0m[36m  - .correlation_id (1616512461)[0m
@@ -413,7 +413,7 @@ Debug = true
 [33m[stage-5] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-5] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-5] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-5] [Decoder] [0m[36m  - .session_id (68135224)[0m
+[33m[stage-5] [Decoder] [0m[36m  - .session_id (53530788)[0m
 [33m[stage-5] [Decoder] [0m[36m  - .num_responses (0)[0m
 [33m[stage-5] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-5] [0m[92m✓ Correlation ID: 1616512461[0m
@@ -425,22 +425,22 @@ Debug = true
 [33m[stage-5] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: hn6[0m
-[33m[stage-4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-4] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-4] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-4] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-4] [0m[94mSending "Fetch" (version: 16) request (Correlation id: 96710698)[0m
@@ -450,7 +450,7 @@ Debug = true
 [33m[stage-4] [0m[36m0000 | 00 00 00 60 00 01 00 10 05 c3 b0 2a 00 09 6b 61 | ...`.......*..ka[0m
 [33m[stage-4] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-4] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-4] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 44 86 02 00 | ............D...[0m
+[33m[stage-4] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 43 83 02 00 | ............C...[0m
 [33m[stage-4] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-4] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-4] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -458,9 +458,9 @@ Debug = true
 [33m[stage-4] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-4] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-4] [0m[36m0000 | 00 00 00 48 05 c3 b0 2a 00 00 00 00 00 00 00 01 | ...H...*........[0m
-[33m[stage-4] [0m[36m0010 | 9e d3 25 02 00 00 00 00 00 00 00 00 00 00 00 00 | ..%.............[0m
-[33m[stage-4] [0m[36m0020 | 00 00 44 86 02 00 00 00 00 00 64 ff ff ff ff ff | ..D.......d.....[0m
+[33m[stage-4] [0m[36m0000 | 00 00 00 48 05 c3 b0 2a 00 00 00 00 00 00 00 03 | ...H...*........[0m
+[33m[stage-4] [0m[36m0010 | 7e 75 e1 02 00 00 00 00 00 00 00 00 00 00 00 00 | ~u..............[0m
+[33m[stage-4] [0m[36m0020 | 00 00 43 83 02 00 00 00 00 00 64 ff ff ff ff ff | ..C.......d.....[0m
 [33m[stage-4] [0m[36m0030 | ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff | ................[0m
 [33m[stage-4] [0m[36m0040 | ff ff ff 01 ff ff ff ff 01 00 00 00             | ............[0m
 [33m[stage-4] [0m[36m[0m
@@ -470,10 +470,10 @@ Debug = true
 [33m[stage-4] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-4] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-4] [Decoder] [0m[36m  - .session_id (27185957)[0m
+[33m[stage-4] [Decoder] [0m[36m  - .session_id (58619361)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-4] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-4] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000004486)[0m
+[33m[stage-4] [Decoder] [0m[36m    - .topic_id (00000000-0000-0000-0000-000000004383)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-4] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-4] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -490,7 +490,7 @@ Debug = true
 [33m[stage-4] [0m[92m✓ Correlation ID: 96710698[0m
 [33m[stage-4] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-4] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000004486[0m
+[33m[stage-4] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-0000-0000-000000004383[0m
 [33m[stage-4] [0m[92m    ✓ PartitionResponse[0] Error code: 100 (UNKNOWN_TOPIC_ID)[0m
 [33m[stage-4] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-4] [0m[92m    ✓ RecordBatches: [][0m
@@ -499,22 +499,22 @@ Debug = true
 [33m[stage-4] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-3] [0m[94mRunning tests for Stage #3: cm4[0m
-[33m[stage-3] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-3] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-3] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-3] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-3] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-3] [0m[94mSending "Fetch" (version: 16) request (Correlation id: 254678266)[0m
@@ -524,7 +524,7 @@ Debug = true
 [33m[stage-3] [0m[36m0000 | 00 00 00 60 00 01 00 10 0f 2e 14 fa 00 09 6b 61 | ...`..........ka[0m
 [33m[stage-3] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-3] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-3] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 14 02 00 | ....@...........[0m
+[33m[stage-3] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 96 02 00 | ....@...........[0m
 [33m[stage-3] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-3] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -532,9 +532,9 @@ Debug = true
 [33m[stage-3] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-3] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-3] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-3] [0m[36m0000 | 00 00 00 48 0f 2e 14 fa 00 00 00 00 00 00 00 03 | ...H............[0m
-[33m[stage-3] [0m[36m0010 | 9d 37 90 02 00 00 00 00 00 00 40 00 80 00 00 00 | .7........@.....[0m
-[33m[stage-3] [0m[36m0020 | 00 00 00 14 02 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
+[33m[stage-3] [0m[36m0000 | 00 00 00 48 0f 2e 14 fa 00 00 00 00 00 00 00 0f | ...H............[0m
+[33m[stage-3] [0m[36m0010 | 33 98 ca 02 00 00 00 00 00 00 40 00 80 00 00 00 | 3.........@.....[0m
+[33m[stage-3] [0m[36m0020 | 00 00 00 96 02 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0030 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-3] [0m[36m0040 | 00 00 00 00 ff ff ff ff 01 00 00 00             | ............[0m
 [33m[stage-3] [0m[36m[0m
@@ -544,10 +544,10 @@ Debug = true
 [33m[stage-3] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-3] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-3] [Decoder] [0m[36m  - .session_id (60635024)[0m
+[33m[stage-3] [Decoder] [0m[36m  - .session_id (255039690)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-3] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000014)[0m
+[33m[stage-3] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000096)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-3] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-3] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -564,7 +564,7 @@ Debug = true
 [33m[stage-3] [0m[92m✓ Correlation ID: 254678266[0m
 [33m[stage-3] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-3] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000014[0m
+[33m[stage-3] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000096[0m
 [33m[stage-3] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
 [33m[stage-3] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-3] [0m[92m    ✓ RecordBatches: [][0m
@@ -573,22 +573,22 @@ Debug = true
 [33m[stage-3] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: eg2[0m
-[33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-2] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-2] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-2] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-2] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-2] [0m[94mSending "Fetch" (version: 16) request (Correlation id: 1893237013)[0m
@@ -598,7 +598,7 @@ Debug = true
 [33m[stage-2] [0m[36m0000 | 00 00 00 60 00 01 00 10 70 d8 81 15 00 09 6b 61 | ...`....p.....ka[0m
 [33m[stage-2] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-2] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-2] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 26 02 00 | ....@........&..[0m
+[33m[stage-2] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 20 02 00 | ....@........ ..[0m
 [33m[stage-2] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-2] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-2] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -606,16 +606,17 @@ Debug = true
 [33m[stage-2] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-2] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-2] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-2] [0m[36m0000 | 00 00 00 98 70 d8 81 15 00 00 00 00 00 00 00 00 | ....p...........[0m
-[33m[stage-2] [0m[36m0010 | 92 cc 59 02 00 00 00 00 00 00 40 00 80 00 00 00 | ..Y.......@.....[0m
-[33m[stage-2] [0m[36m0020 | 00 00 00 26 02 00 00 00 00 00 00 00 00 00 00 00 | ...&............[0m
+[33m[stage-2] [0m[36m0000 | 00 00 00 a6 70 d8 81 15 00 00 00 00 00 00 00 09 | ....p...........[0m
+[33m[stage-2] [0m[36m0010 | 93 62 0b 02 00 00 00 00 00 00 40 00 80 00 00 00 | .b........@.....[0m
+[33m[stage-2] [0m[36m0020 | 00 00 00 20 02 00 00 00 00 00 00 00 00 00 00 00 | ... ............[0m
 [33m[stage-2] [0m[36m0030 | 00 00 01 00 00 00 00 00 00 00 01 00 00 00 00 00 | ................[0m
-[33m[stage-2] [0m[36m0040 | 00 00 00 00 ff ff ff ff 51 00 00 00 00 00 00 00 | ........Q.......[0m
-[33m[stage-2] [0m[36m0050 | 00 00 00 00 44 00 00 00 00 02 64 61 7c 4a 00 00 | ....D.....da|J..[0m
+[33m[stage-2] [0m[36m0040 | 00 00 00 00 ff ff ff ff 5f 00 00 00 00 00 00 00 | ........_.......[0m
+[33m[stage-2] [0m[36m0050 | 00 00 00 00 52 00 00 00 00 02 8b aa 87 2a 00 00 | ....R........*..[0m
 [33m[stage-2] [0m[36m0060 | 00 00 00 00 00 00 01 91 e0 5b 6d 8b 00 00 01 91 | .........[m.....[0m
 [33m[stage-2] [0m[36m0070 | e0 5b 6d 8b 00 00 00 00 00 00 00 00 00 00 00 00 | .[m.............[0m
-[33m[stage-2] [0m[36m0080 | 00 00 00 00 00 01 24 00 00 00 01 18 48 65 6c 6c | ......$.....Hell[0m
-[33m[stage-2] [0m[36m0090 | 6f 20 45 61 72 74 68 21 00 00 00 00             | o Earth!....[0m
+[33m[stage-2] [0m[36m0080 | 00 00 00 00 00 01 40 00 00 00 01 34 48 65 6c 6c | ......@....4Hell[0m
+[33m[stage-2] [0m[36m0090 | 6f 20 52 65 76 65 72 73 65 20 45 6e 67 69 6e 65 | o Reverse Engine[0m
+[33m[stage-2] [0m[36m00a0 | 65 72 69 6e 67 21 00 00 00 00                   | ering!....[0m
 [33m[stage-2] [0m[36m[0m
 [33m[stage-2] [Decoder] [0m[36m- .ResponseHeader[0m
 [33m[stage-2] [Decoder] [0m[36m  - .correlation_id (1893237013)[0m
@@ -623,10 +624,10 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-2] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-2] [Decoder] [0m[36m  - .session_id (9620569)[0m
+[33m[stage-2] [Decoder] [0m[36m  - .session_id (160653835)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-2] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000026)[0m
+[33m[stage-2] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000020)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-2] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-2] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -636,13 +637,13 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m      - .log_start_offset (0)[0m
 [33m[stage-2] [Decoder] [0m[36m      - .num_aborted_transactions (0)[0m
 [33m[stage-2] [Decoder] [0m[36m      - .preferred_read_replica (-1)[0m
-[33m[stage-2] [Decoder] [0m[36m      - .compact_records_length (80)[0m
+[33m[stage-2] [Decoder] [0m[36m      - .compact_records_length (94)[0m
 [33m[stage-2] [Decoder] [0m[36m      - .RecordBatch[0][0m
 [33m[stage-2] [Decoder] [0m[36m        - .base_offset (0)[0m
-[33m[stage-2] [Decoder] [0m[36m        - .batch_length (68)[0m
+[33m[stage-2] [Decoder] [0m[36m        - .batch_length (82)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .partition_leader_epoch (0)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .magic_byte (2)[0m
-[33m[stage-2] [Decoder] [0m[36m        - .crc (1684110410)[0m
+[33m[stage-2] [Decoder] [0m[36m        - .crc (-1951758550)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .record_attributes (0)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .last_offset_delta (0)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .base_timestamp (1726045973899)[0m
@@ -652,14 +653,14 @@ Debug = true
 [33m[stage-2] [Decoder] [0m[36m        - .base_sequence (0)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .num_records (1)[0m
 [33m[stage-2] [Decoder] [0m[36m        - .Record[0][0m
-[33m[stage-2] [Decoder] [0m[36m          - .length (18)[0m
+[33m[stage-2] [Decoder] [0m[36m          - .length (32)[0m
 [33m[stage-2] [Decoder] [0m[36m          - .attributes (0)[0m
 [33m[stage-2] [Decoder] [0m[36m          - .timestamp_delta (0)[0m
 [33m[stage-2] [Decoder] [0m[36m          - .offset_delta (0)[0m
 [33m[stage-2] [Decoder] [0m[36m          - .key_length (-1)[0m
 [33m[stage-2] [Decoder] [0m[36m          - .key ("")[0m
-[33m[stage-2] [Decoder] [0m[36m          - .value_length (12)[0m
-[33m[stage-2] [Decoder] [0m[36m          - .value ("Hello Earth!")[0m
+[33m[stage-2] [Decoder] [0m[36m          - .value_length (26)[0m
+[33m[stage-2] [Decoder] [0m[36m          - .value ("Hello Reverse Engineering!")[0m
 [33m[stage-2] [Decoder] [0m[36m          - .num_headers (0)[0m
 [33m[stage-2] [Decoder] [0m[36m      - .TAG_BUFFER[0m
 [33m[stage-2] [Decoder] [0m[36m    - .TAG_BUFFER[0m
@@ -667,33 +668,33 @@ Debug = true
 [33m[stage-2] [0m[92m✓ Correlation ID: 1893237013[0m
 [33m[stage-2] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-2] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000026[0m
+[33m[stage-2] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000020[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
 [33m[stage-2] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-2] [0m[92m      ✓ RecordBatch[0] BaseOffset: 0[0m
-[33m[stage-2] [0m[92m        ✓ Record[0] Value: Hello Earth![0m
+[33m[stage-2] [0m[92m        ✓ Record[0] Value: Hello Reverse Engineering![0m
 [33m[stage-2] [0m[92m✓ RecordBatch bytes match with the contents on disk[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 [33m[stage-2] [0m[36mTerminating program[0m
 [33m[stage-2] [0m[36mProgram terminated successfully[0m
 
 [33m[stage-1] [0m[94mRunning tests for Stage #1: fd8[0m
-[33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36mWriting log files to: /tmp/kraft-combined-logs[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/server.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/meta.properties[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/.kafka_cleanshutdown[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/partition.metadata[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/partition.metadata[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/partition.metadata[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/bar-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/baz-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-0/00000000000000000000.log[0m
-[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/foo-1/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-0/00000000000000000000.log[0m
+[33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/pax-1/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[36m  - Wrote file to: /tmp/kraft-combined-logs/__cluster_metadata-0/00000000000000000000.log[0m
 [33m[stage-1] [Serializer] [0m[94mFinished writing log files to: /tmp/kraft-combined-logs[0m
+[33m[stage-1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[stage-1] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[stage-1] [0m[36mConnection to broker at localhost:9092 successful[0m
 [33m[stage-1] [0m[94mSending "Fetch" (version: 16) request (Correlation id: 1698452642)[0m
@@ -703,7 +704,7 @@ Debug = true
 [33m[stage-1] [0m[36m0000 | 00 00 00 60 00 01 00 10 65 3c 54 a2 00 09 6b 61 | ...`....e<T...ka[0m
 [33m[stage-1] [0m[36m0010 | 66 6b 61 2d 63 6c 69 00 00 00 01 f4 00 00 00 01 | fka-cli.........[0m
 [33m[stage-1] [0m[36m0020 | 03 20 00 00 00 00 00 00 00 00 00 00 00 02 00 00 | . ..............[0m
-[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 45 02 00 | ....@........E..[0m
+[33m[stage-1] [0m[36m0030 | 00 00 00 00 40 00 80 00 00 00 00 00 00 15 02 00 | ....@...........[0m
 [33m[stage-1] [0m[36m0040 | 00 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ff | ................[0m
 [33m[stage-1] [0m[36m0050 | ff ff ff ff ff ff ff ff ff ff ff 00 10 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0060 | 00 01 01 00                                     | ....[0m
@@ -711,22 +712,21 @@ Debug = true
 [33m[stage-1] [0m[36mHexdump of received "Fetch" response: [0m
 [33m[stage-1] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[stage-1] [0m[36m-----+-------------------------------------------------+-----------------[0m
-[33m[stage-1] [0m[36m0000 | 00 00 00 f0 65 3c 54 a2 00 00 00 00 00 00 00 0d | ....e<T.........[0m
-[33m[stage-1] [0m[36m0010 | dd 50 5c 02 00 00 00 00 00 00 40 00 80 00 00 00 | .P\.......@.....[0m
-[33m[stage-1] [0m[36m0020 | 00 00 00 45 02 00 00 00 00 00 00 00 00 00 00 00 | ...E............[0m
+[33m[stage-1] [0m[36m0000 | 00 00 00 ec 65 3c 54 a2 00 00 00 00 00 00 00 0e | ....e<T.........[0m
+[33m[stage-1] [0m[36m0010 | c6 b6 57 02 00 00 00 00 00 00 40 00 80 00 00 00 | ..W.......@.....[0m
+[33m[stage-1] [0m[36m0020 | 00 00 00 15 02 00 00 00 00 00 00 00 00 00 00 00 | ................[0m
 [33m[stage-1] [0m[36m0030 | 00 00 02 00 00 00 00 00 00 00 02 00 00 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0040 | 00 00 00 00 ff ff ff ff a8 01 00 00 00 00 00 00 | ................[0m
-[33m[stage-1] [0m[36m0050 | 00 00 00 00 00 4b 00 00 00 00 02 55 60 53 93 00 | .....K.....U`S..[0m
+[33m[stage-1] [0m[36m0040 | 00 00 00 00 ff ff ff ff a4 01 00 00 00 00 00 00 | ................[0m
+[33m[stage-1] [0m[36m0050 | 00 00 00 00 00 44 00 00 00 00 02 98 ec 18 d3 00 | .....D..........[0m
 [33m[stage-1] [0m[36m0060 | 00 00 00 00 00 00 00 01 91 e0 5b 6d 8b 00 00 01 | ..........[m....[0m
 [33m[stage-1] [0m[36m0070 | 91 e0 5b 6d 8b 00 00 00 00 00 00 00 00 00 00 00 | ..[m............[0m
-[33m[stage-1] [0m[36m0080 | 00 00 00 00 00 00 01 32 00 00 00 01 26 48 65 6c | .......2....&Hel[0m
-[33m[stage-1] [0m[36m0090 | 6c 6f 20 43 6f 64 65 43 72 61 66 74 65 72 73 21 | lo CodeCrafters![0m
-[33m[stage-1] [0m[36m00a0 | 00 00 00 00 00 00 00 00 01 00 00 00 44 00 00 00 | ............D...[0m
-[33m[stage-1] [0m[36m00b0 | 00 02 98 ec 18 d3 00 00 00 00 00 00 00 00 01 91 | ................[0m
-[33m[stage-1] [0m[36m00c0 | e0 5b 6d 8b 00 00 01 91 e0 5b 6d 8b 00 00 00 00 | .[m......[m.....[0m
-[33m[stage-1] [0m[36m00d0 | 00 00 00 00 00 00 00 00 00 00 00 00 00 01 24 00 | ..............$.[0m
-[33m[stage-1] [0m[36m00e0 | 00 00 01 18 48 65 6c 6c 6f 20 57 6f 72 6c 64 21 | ....Hello World![0m
-[33m[stage-1] [0m[36m00f0 | 00 00 00 00                                     | ....[0m
+[33m[stage-1] [0m[36m0080 | 00 00 00 00 00 00 01 24 00 00 00 01 18 48 65 6c | .......$.....Hel[0m
+[33m[stage-1] [0m[36m0090 | 6c 6f 20 57 6f 72 6c 64 21 00 00 00 00 00 00 00 | lo World!.......[0m
+[33m[stage-1] [0m[36m00a0 | 00 01 00 00 00 47 00 00 00 00 02 b8 7c 9c ff 00 | .....G......|...[0m
+[33m[stage-1] [0m[36m00b0 | 00 00 00 00 00 00 00 01 91 e0 5b 6d 8b 00 00 01 | ..........[m....[0m
+[33m[stage-1] [0m[36m00c0 | 91 e0 5b 6d 8b 00 00 00 00 00 00 00 00 00 00 00 | ..[m............[0m
+[33m[stage-1] [0m[36m00d0 | 00 00 00 00 00 00 01 2a 00 00 00 01 1e 48 65 6c | .......*.....Hel[0m
+[33m[stage-1] [0m[36m00e0 | 6c 6f 20 55 6e 69 76 65 72 73 65 21 00 00 00 00 | lo Universe!....[0m
 [33m[stage-1] [0m[36m[0m
 [33m[stage-1] [Decoder] [0m[36m- .ResponseHeader[0m
 [33m[stage-1] [Decoder] [0m[36m  - .correlation_id (1698452642)[0m
@@ -734,10 +734,10 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m- .ResponseBody[0m
 [33m[stage-1] [Decoder] [0m[36m  - .throttle_time_ms (0)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .error_code (0)[0m
-[33m[stage-1] [Decoder] [0m[36m  - .session_id (232607836)[0m
+[33m[stage-1] [Decoder] [0m[36m  - .session_id (247903831)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .num_responses (1)[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TopicResponse[0][0m
-[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000045)[0m
+[33m[stage-1] [Decoder] [0m[36m    - .topic_id (00000000-0000-4000-8000-000000000015)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .num_partitions (1)[0m
 [33m[stage-1] [Decoder] [0m[36m    - .PartitionResponse[0][0m
 [33m[stage-1] [Decoder] [0m[36m      - .partition_index (0)[0m
@@ -747,33 +747,9 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m      - .log_start_offset (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .num_aborted_transactions (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .preferred_read_replica (-1)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .compact_records_length (167)[0m
+[33m[stage-1] [Decoder] [0m[36m      - .compact_records_length (163)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .RecordBatch[0][0m
 [33m[stage-1] [Decoder] [0m[36m        - .base_offset (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .batch_length (75)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .partition_leader_epoch (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .magic_byte (2)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .crc (1432376211)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .record_attributes (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .last_offset_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_timestamp (1726045973899)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .max_timestamp (1726045973899)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .producer_id (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .producer_epoch (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_sequence (0)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .num_records (1)[0m
-[33m[stage-1] [Decoder] [0m[36m        - .Record[0][0m
-[33m[stage-1] [Decoder] [0m[36m          - .length (25)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .attributes (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .timestamp_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .offset_delta (0)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .key_length (-1)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .key ("")[0m
-[33m[stage-1] [Decoder] [0m[36m          - .value_length (19)[0m
-[33m[stage-1] [Decoder] [0m[36m          - .value ("Hello CodeCrafters!")[0m
-[33m[stage-1] [Decoder] [0m[36m          - .num_headers (0)[0m
-[33m[stage-1] [Decoder] [0m[36m      - .RecordBatch[1][0m
-[33m[stage-1] [Decoder] [0m[36m        - .base_offset (1)[0m
 [33m[stage-1] [Decoder] [0m[36m        - .batch_length (68)[0m
 [33m[stage-1] [Decoder] [0m[36m        - .partition_leader_epoch (0)[0m
 [33m[stage-1] [Decoder] [0m[36m        - .magic_byte (2)[0m
@@ -796,19 +772,43 @@ Debug = true
 [33m[stage-1] [Decoder] [0m[36m          - .value_length (12)[0m
 [33m[stage-1] [Decoder] [0m[36m          - .value ("Hello World!")[0m
 [33m[stage-1] [Decoder] [0m[36m          - .num_headers (0)[0m
+[33m[stage-1] [Decoder] [0m[36m      - .RecordBatch[1][0m
+[33m[stage-1] [Decoder] [0m[36m        - .base_offset (1)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .batch_length (71)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .partition_leader_epoch (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .magic_byte (2)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .crc (-1199792897)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .record_attributes (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .last_offset_delta (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .base_timestamp (1726045973899)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .max_timestamp (1726045973899)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .producer_id (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .producer_epoch (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .base_sequence (0)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .num_records (1)[0m
+[33m[stage-1] [Decoder] [0m[36m        - .Record[0][0m
+[33m[stage-1] [Decoder] [0m[36m          - .length (21)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .attributes (0)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .timestamp_delta (0)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .offset_delta (0)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .key_length (-1)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .key ("")[0m
+[33m[stage-1] [Decoder] [0m[36m          - .value_length (15)[0m
+[33m[stage-1] [Decoder] [0m[36m          - .value ("Hello Universe!")[0m
+[33m[stage-1] [Decoder] [0m[36m          - .num_headers (0)[0m
 [33m[stage-1] [Decoder] [0m[36m      - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
 [33m[stage-1] [Decoder] [0m[36m  - .TAG_BUFFER[0m
 [33m[stage-1] [0m[92m✓ Correlation ID: 1698452642[0m
 [33m[stage-1] [0m[92m✓ Throttle Time: 0[0m
 [33m[stage-1] [0m[92m✓ Error Code: 0 (NO_ERROR)[0m
-[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000045[0m
+[33m[stage-1] [0m[92m  ✓ TopicResponse[0] Topic UUID: 00000000-0000-4000-8000-000000000015[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Error code: 0 (NO_ERROR)[0m
 [33m[stage-1] [0m[92m    ✓ PartitionResponse[0] Partition Index: 0[0m
 [33m[stage-1] [0m[92m      ✓ RecordBatch[0] BaseOffset: 0[0m
-[33m[stage-1] [0m[92m        ✓ Record[0] Value: Hello CodeCrafters![0m
-[33m[stage-1] [0m[92m      ✓ RecordBatch[1] BaseOffset: 1[0m
 [33m[stage-1] [0m[92m        ✓ Record[0] Value: Hello World![0m
+[33m[stage-1] [0m[92m      ✓ RecordBatch[1] BaseOffset: 1[0m
+[33m[stage-1] [0m[92m        ✓ Record[0] Value: Hello Universe![0m
 [33m[stage-1] [0m[92m✓ RecordBatch bytes match with the contents on disk[0m
 [33m[stage-1] [0m[92mTest passed.[0m
 [33m[stage-1] [0m[36mTerminating program[0m

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -42,7 +42,7 @@ var testerDefinition = tester_definition.TesterDefinition{
 		},
 		{
 			Slug:     "gs0",
-			TestFunc: testAPIVersionwFetchKey,
+			TestFunc: testAPIVersionWithFetchKey,
 		},
 		{
 			Slug:     "dh6",
@@ -50,7 +50,7 @@ var testerDefinition = tester_definition.TesterDefinition{
 		},
 		{
 			Slug:     "hn6",
-			TestFunc: testFetchWithUnkownTopicID,
+			TestFunc: testFetchWithUnknownTopicID,
 		},
 		{
 			Slug:     "cm4",
@@ -66,7 +66,7 @@ var testerDefinition = tester_definition.TesterDefinition{
 		},
 		{
 			Slug:     "yk1",
-			TestFunc: testAPIVersionwDescribeTopicPartitions,
+			TestFunc: testAPIVersionWithDescribeTopicPartitions,
 		},
 		{
 			Slug:     "vt6",

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -1,28 +1,12 @@
 package kafkaapi
 
 import (
-	"fmt"
-
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
-
-func GetDescribeTopicPartition() {
-	broker := protocol.NewBroker("localhost:9092")
-	if err := broker.Connect(); err != nil {
-		panic(err)
-	}
-	defer broker.Close()
-
-	response, err := DescribeTopicPartitions(broker)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("\nTopic name: %s <-> Topic ID: %s\n", response.Topics[0].Name, response.Topics[0].TopicID)
-}
 
 func EncodeDescribeTopicPartitionsRequest(request *DescribeTopicPartitionsRequest) []byte {
 	encoder := realencoder.RealEncoder{}

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -30,7 +30,8 @@ func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-			return nil, decodingErr.WithAddedContext("Response Header").WithAddedContext("Fetch Response v16")
+			detailedError := decodingErr.WithAddedContext("Response Header").WithAddedContext("Fetch Response v16")
+			return nil, decoder.FormatDetailedError(detailedError.Error())
 		}
 		return nil, err
 	}


### PR DESCRIPTION
This pull request makes several changes to improve the logging consistency across multiple stages of the Kafka tester. The primary change is the replacement of the `logger` variable with `stageLogger` in various functions to ensure that the correct logger instance is used throughout the stages.

Improvements to logging consistency:

* [`internal/stage1.go`](diffhunk://#diff-9d01b280d6dcb5da94d3c21f3cf29cf5a5d6d0ca4cced2b68dffe9f719ff166dL13-R19): Replaced `logger` with `stageLogger` in the `testBindToPort` function to ensure consistent logging. [[1]](diffhunk://#diff-9d01b280d6dcb5da94d3c21f3cf29cf5a5d6d0ca4cced2b68dffe9f719ff166dL13-R19) [[2]](diffhunk://#diff-9d01b280d6dcb5da94d3c21f3cf29cf5a5d6d0ca4cced2b68dffe9f719ff166dL29-R28)
* [`internal/stage2.go`](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL19-R35): Updated the `testHardcodedCorrelationId` function to use `stageLogger` instead of `logger` for all logging operations. [[1]](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL19-R35) [[2]](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL53-R55) [[3]](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL64-R71) [[4]](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL79-R82) [[5]](diffhunk://#diff-05b2ca94e5a39ef45b42380250c030d9c5df918b8953486bec6d078e2b12753dL90-R98)
* [`internal/stage3.go`](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30R5): Modified the `testCorrelationId` function to use `stageLogger` for logging, ensuring consistency. [[1]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30R5) [[2]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30L13-R35) [[3]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30L53-R55) [[4]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30L64-R71) [[5]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30L79-R82) [[6]](diffhunk://#diff-5fd62a292f58fe0f055d1a40f1bb25addf935882fdfd02cbc728cfe06da42a30L90-R98)
* [`internal/stage4.go`](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248R5-R37): Updated the `testAPIVersionErrorCase` function to use `stageLogger` for all logging activities. [[1]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248R5-R37) [[2]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248L53-R55) [[3]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248L64-R71) [[4]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248L79-R82) [[5]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248L90-R91) [[6]](diffhunk://#diff-c66a7c68c7a53a869dfa88ba4949124642b972cb21c541f5b2f684dd1b8c9248L100-R114)
* [`internal/stage5.go`](diffhunk://#diff-863ccc69edde2ff703375190e9ff1a492ac2a790364bd6ec8501d522dc614ca0L16-R34): Ensured that the `testAPIVersion` function uses `stageLogger` for consistent logging. [[1]](diffhunk://#diff-863ccc69edde2ff703375190e9ff1a492ac2a790364bd6ec8501d522dc614ca0L16-R34) [[2]](diffhunk://#diff-863ccc69edde2ff703375190e9ff1a492ac2a790364bd6ec8501d522dc614ca0L50-R86)
* [`internal/stagec1.go`](diffhunk://#diff-a4cb952e363e33e1fc6a701f056b6624a038175b5aa642d86e51764f96b6478dR5-R33): Changed the `testSequentialRequests` function to use `stageLogger` instead of `logger` for logging.