### PR TITLE
Decrease compact_records_length when parsing partitions

### DIFF
--- a/protocol/api/fetch_response.go
+++ b/protocol/api/fetch_response.go
@@ -262,6 +262,7 @@ func (pr *PartitionResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logg
 			return err
 		}
 		pr.RecordBatches = append(pr.RecordBatches, recordBatch)
+		numBytes -= int(recordBatch.BatchLength + 12)
 		k++
 	}
 	_, err = pd.GetEmptyTaggedFieldArray()

--- a/protocol/api/fetch_response.go
+++ b/protocol/api/fetch_response.go
@@ -262,6 +262,9 @@ func (pr *PartitionResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logg
 			return err
 		}
 		pr.RecordBatches = append(pr.RecordBatches, recordBatch)
+
+		// Adding back 12 bytes before subtracting from numBytes
+		// because BatchLength excludes BaseOffset (8 bytes) and itself (4 bytes)
 		numBytes -= int(recordBatch.BatchLength + 12)
 		k++
 	}


### PR DESCRIPTION
Issue:

Currently, we're not decreasing **compact_records_length** (numBytes), so the [stop condition](https://github.com/codecrafters-io/kafka-tester/blob/763a39a0c9798b0df92f917a75ed2374bf8f8839/protocol/api/fetch_response.go#L254) relies solely on **pd.Remaining()**:


<img width="787" alt="image" src="https://github.com/user-attachments/assets/85875b2e-13d0-4852-9966-7dc23fdc6e3e" />

However, users could mistakenly have extra bytes at the end of the response, leading to confusing [parsing results](https://forum.codecrafters.io/t/stuck-on-stage-fd8-tester-failing-to-test-valid-reponse/8085).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response data processing by refining the way remaining bytes are calculated, ensuring more precise and stable data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->