### PR TITLE
Simplify Broker.SendAndReceive to include encoding + logging

### DIFF
--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -52,7 +52,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	err = broker.Send(message)
 	if err != nil {
@@ -62,7 +62,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
 	decoder := realdecoder.RealDecoder{}
 	decoder.Init(response)

--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -26,11 +27,11 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
@@ -52,7 +53,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	err = broker.Send(message)
 	if err != nil {
@@ -62,7 +63,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
 	decoder := realdecoder.RealDecoder{}
 	decoder.Init(response)

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
@@ -27,11 +28,11 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -10,6 +10,7 @@ import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -29,11 +30,11 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	correlationId := getRandomCorrelationId()
 	apiVersion := getInvalidAPIVersion()
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
@@ -52,7 +53,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	err = broker.Send(message)
 	if err != nil {
@@ -62,7 +63,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
 	decoder := realdecoder.RealDecoder{}
 	decoder.Init(response)

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -47,7 +47,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -49,13 +49,13 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -25,11 +26,11 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	correlationId := getRandomCorrelationId()
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -48,15 +47,10 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -6,7 +6,6 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -51,15 +50,10 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			},
 		}
 
-		message := kafkaapi.EncodeApiVersionsRequest(&request)
-		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-		response, err := broker.SendAndReceive(message)
+		response, err := broker.SendAndReceiveNew(&request, stageLogger)
 		if err != nil {
 			return err
 		}
-		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
@@ -51,13 +52,13 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 
 		message := kafkaapi.EncodeApiVersionsRequest(&request)
 		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 		response, err := broker.SendAndReceive(message)
 		if err != nil {
 			return err
 		}
-		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -34,7 +34,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	}(broker)
 
 	requestCount := random.RandomInt(2, 5)
-	for i := 0; i < requestCount; i++ {
+	for i := range requestCount {
 		correlationId := getRandomCorrelationId()
 		request := kafkaapi.ApiVersionsRequest{
 			Header: kafkaapi.RequestHeader{
@@ -50,6 +50,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			},
 		}
 
+		stageLogger.Infof("Sending request %d of %d:", i+1, requestCount)
 		response, err := broker.SendAndReceiveNew(&request, stageLogger)
 		if err != nil {
 			return err

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -51,7 +51,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		}
 
 		stageLogger.Infof("Sending request %d of %d:", i+1, requestCount)
-		response, err := broker.SendAndReceiveNew(&request, stageLogger)
+		response, err := broker.SendAndReceive(&request, stageLogger)
 		if err != nil {
 			return err
 		}

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -25,11 +26,11 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		return err
 	}
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_c2.go
+++ b/internal/stage_c2.go
@@ -62,7 +62,7 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 
 		message := kafkaapi.EncodeApiVersionsRequest(&request)
 		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, clientCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 		err := client.Send(message)
 		if err != nil {
@@ -78,7 +78,7 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		if err != nil {
 			return err
 		}
-		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {

--- a/internal/stage_c2.go
+++ b/internal/stage_c2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
@@ -26,11 +27,11 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	}
 
 	clientCount := random.RandomInt(2, 4)
-	clients := make([]*protocol.Broker, clientCount)
+	clients := make([]*kafka_broker.Broker, clientCount)
 	correlationIds := make([]int32, clientCount)
 
 	for i := 0; i < clientCount; i++ {
-		clients[i] = protocol.NewBroker("localhost:9092")
+		clients[i] = kafka_broker.NewBroker("localhost:9092")
 		if err := clients[i].ConnectWithRetries(b, stageLogger); err != nil {
 			return err
 		}

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -23,11 +24,11 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -45,7 +45,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -47,13 +47,13 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -46,15 +45,10 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -51,13 +51,13 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -49,7 +49,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -24,11 +25,11 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -50,15 +49,10 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -50,13 +50,13 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -48,7 +48,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -49,15 +48,10 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -48,7 +48,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -49,15 +48,10 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -50,13 +50,13 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -57,15 +56,10 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -56,7 +56,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -58,13 +58,13 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 
 	message := kafkaapi.EncodeDescribeTopicPartitionsRequest(&request)
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -47,15 +46,10 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := kafkaapi.EncodeApiVersionsRequest(&request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -24,11 +25,11 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 
 	correlationId := getRandomCorrelationId()
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -46,7 +46,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -48,13 +48,13 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 
 	message := kafkaapi.EncodeApiVersionsRequest(&request)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -51,15 +50,10 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		},
 	}
 
-	message := kafkaapi.EncodeFetchRequest(&request)
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -22,11 +23,11 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -52,13 +52,13 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 
 	message := kafkaapi.EncodeFetchRequest(&request)
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -50,7 +50,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -68,7 +68,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, stageLogger)
+	response, err := broker.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -26,11 +27,11 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 	UUID := common.TOPICX_UUID
 	// ToDo: Research on what is NULL v Empty arrays
 
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, stageLogger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -69,15 +68,10 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		},
 	}
 
-	message := kafkaapi.EncodeFetchRequest(&request)
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -70,13 +70,13 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 
 	message := kafkaapi.EncodeFetchRequest(&request)
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -65,7 +65,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, logger)
+	response, err := broker.SendAndReceive(&request, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -66,15 +65,10 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		},
 	}
 
-	message := kafkaapi.EncodeFetchRequest(&request)
-	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, logger)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -67,13 +67,13 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 
 	message := kafkaapi.EncodeFetchRequest(&request)
 	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -65,7 +65,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, logger)
+	response, err := broker.SendAndReceive(&request, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -67,13 +67,13 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 
 	message := kafkaapi.EncodeFetchRequest(&request)
 	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -66,15 +65,10 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := kafkaapi.EncodeFetchRequest(&request)
-	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, logger)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
@@ -66,15 +65,10 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	message := kafkaapi.EncodeFetchRequest(&request)
-	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
-
-	response, err := broker.SendAndReceive(message)
+	response, err := broker.SendAndReceiveNew(&request, logger)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -67,13 +67,13 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 
 	message := kafkaapi.EncodeFetchRequest(&request)
 	logger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", GetFormattedHexdump(message))
+	logger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 
 	response, err := broker.SendAndReceive(message)
 	if err != nil {
 		return err
 	}
-	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", GetFormattedHexdump(response.RawBytes))
+	logger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, logger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_broker"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -23,11 +24,11 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 
 	correlationId := getRandomCorrelationId()
-	broker := protocol.NewBroker("localhost:9092")
+	broker := kafka_broker.NewBroker("localhost:9092")
 	if err := broker.ConnectWithRetries(b, logger); err != nil {
 		return err
 	}
-	defer func(broker *protocol.Broker) {
+	defer func(broker *kafka_broker.Broker) {
 		_ = broker.Close()
 	}(broker)
 

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -65,7 +65,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	response, err := broker.SendAndReceiveNew(&request, logger)
+	response, err := broker.SendAndReceive(&request, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/test_helpers/fixtures/concurrent_stages/pass
+++ b/internal/test_helpers/fixtures/concurrent_stages/pass
@@ -4,7 +4,8 @@ Debug = true
 [33m[tester::#NH4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[tester::#NH4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[tester::#NH4] [0m[36mConnection to broker at localhost:9092 successful[0m
-[33m[tester::#NH4] [0m[94mSending request 1 of 2: "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
+[33m[tester::#NH4] [0m[94mSending request 1 of 2:[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m
@@ -367,7 +368,8 @@ Debug = true
 [33m[tester::#NH4] [0m[92m✓ API keys array is non-empty[0m
 [33m[tester::#NH4] [0m[92m✓ API version 4 is supported for API_VERSIONS[0m
 [33m[tester::#NH4] [0m[92m✓ Test 1 of 2: Passed[0m
-[33m[tester::#NH4] [0m[94mSending request 2 of 2: "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
+[33m[tester::#NH4] [0m[94mSending request 2 of 2:[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,9 +1,7 @@
 package internal
 
 import (
-	"fmt"
 	"math"
-	"strings"
 
 	"github.com/codecrafters-io/tester-utils/random"
 )
@@ -18,46 +16,4 @@ func getInvalidAPIVersion() int {
 
 func getRandomCorrelationId() int32 {
 	return int32(random.RandomInt(0, math.MaxInt32-1))
-}
-
-func GetFormattedHexdump(data []byte) string {
-	// This is used for logs
-	// Contains headers + vertical & horizontal separators + offset
-	// We use a different format for the error logs
-	var formattedHexdump strings.Builder
-	var asciiChars strings.Builder
-
-	formattedHexdump.WriteString("Idx  | Hex                                             | ASCII\n")
-	formattedHexdump.WriteString("-----+-------------------------------------------------+-----------------\n")
-
-	for i, b := range data {
-		if i%16 == 0 && i != 0 {
-			formattedHexdump.WriteString("| " + asciiChars.String() + "\n")
-			asciiChars.Reset()
-		}
-		if i%16 == 0 {
-			formattedHexdump.WriteString(fmt.Sprintf("%04x | ", i))
-		}
-		formattedHexdump.WriteString(fmt.Sprintf("%02x ", b))
-
-		// Add ASCII representation
-		if b >= 32 && b <= 126 {
-			asciiChars.WriteByte(b)
-		} else {
-			asciiChars.WriteByte('.')
-		}
-	}
-
-	// Pad the last line if necessary
-	if len(data)%16 != 0 {
-		padding := 16 - (len(data) % 16)
-		for i := 0; i < padding; i++ {
-			formattedHexdump.WriteString("   ")
-		}
-	}
-
-	// Add the final ASCII representation
-	formattedHexdump.WriteString("| " + asciiChars.String())
-
-	return formattedHexdump.String()
 }

--- a/local_testing/test.sh
+++ b/local_testing/test.sh
@@ -8,8 +8,8 @@ cd "$(dirname "$0")/.."
 # Build and run
 docker build -t local-kafka-tester -f local_testing/Dockerfile .
 # Run make test
-# docker run --rm -it -v $(pwd):/app local-git-tester make test
+# docker run --rm -it -v $(pwd):/app local-kafka-tester make test
 # Generate fixtures
-# docker run --rm -it -e CODECRAFTERS_RECORD_FIXTURES=true -v $(pwd):/app local-git-tester make test
+# docker run --rm -it -e CODECRAFTERS_RECORD_FIXTURES=true -v $(pwd):/app local-kafka-tester make test
 # Run test_all
 docker run --rm -it -v $(pwd):/app local-kafka-tester make test_all

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -1,7 +1,6 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
@@ -14,7 +13,7 @@ type ApiVersionsRequestBody struct {
 	ClientSoftwareVersion string
 }
 
-func (r *ApiVersionsRequestBody) Encode(enc *encoder.RealEncoder) {
+func (r *ApiVersionsRequestBody) Encode(enc *realencoder.RealEncoder) {
 	if r.Version >= 3 {
 		enc.PutCompactString(r.ClientSoftwareName)
 		enc.PutCompactString(r.ClientSoftwareVersion)

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -2,6 +2,7 @@ package kafkaapi
 
 import (
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type ApiVersionsRequestBody struct {
@@ -24,4 +25,15 @@ func (r *ApiVersionsRequestBody) Encode(enc *encoder.RealEncoder) {
 type ApiVersionsRequest struct {
 	Header RequestHeader
 	Body   ApiVersionsRequestBody
+}
+
+func (r *ApiVersionsRequest) Encode() []byte {
+	encoder := realencoder.RealEncoder{}
+	encoder.Init(make([]byte, 4096))
+
+	r.Header.EncodeV2(&encoder)
+	r.Body.Encode(&encoder)
+	messageBytes := encoder.PackMessage()
+
+	return messageBytes
 }

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -2,20 +2,9 @@ package kafkaapi
 
 import (
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
-
-func EncodeDescribeTopicPartitionsRequest(request *DescribeTopicPartitionsRequest) []byte {
-	encoder := realencoder.RealEncoder{}
-	encoder.Init(make([]byte, 4096))
-
-	request.Encode(&encoder)
-	messageBytes := encoder.PackMessage()
-
-	return messageBytes
-}
 
 // DecodeDescribeTopicPartitionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -1,7 +1,6 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol"
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
@@ -47,37 +46,4 @@ func DecodeDescribeTopicPartitionsHeaderAndResponse(response []byte, logger *log
 	}
 
 	return &responseHeader, &DescribeTopicPartitionsResponse, nil
-}
-
-// DescribeTopicPartitions returns api version response or error
-func DescribeTopicPartitions(b *protocol.Broker) (*DescribeTopicPartitionsResponse, error) {
-	request := DescribeTopicPartitionsRequest{
-		Header: RequestHeader{
-			ApiKey:        75,
-			ApiVersion:    0,
-			CorrelationId: 5,
-			ClientId:      "adminclient-1",
-		},
-		Body: DescribeTopicPartitionsRequestBody{
-			Topics: []TopicName{
-				{
-					Name: "foo",
-				},
-			},
-			ResponsePartitionLimit: 1,
-		},
-	}
-	message := EncodeDescribeTopicPartitionsRequest(&request)
-
-	response, err := b.SendAndReceive(message)
-	if err != nil {
-		return nil, err
-	}
-
-	_, DescribeTopicPartitionsResponse, err := DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, logger.GetLogger(true, ""))
-	if err != nil {
-		return nil, err
-	}
-
-	return DescribeTopicPartitionsResponse, nil
 }

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -2,23 +2,10 @@ package kafkaapi
 
 import (
 	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
-
-func EncodeFetchRequest(request *FetchRequest) []byte {
-	encoder := realencoder.RealEncoder{}
-	// bytes.Buffer{}
-	encoder.Init(make([]byte, 4096))
-
-	request.Header.EncodeV2(&encoder)
-	request.Body.Encode(&encoder)
-	message := encoder.PackMessage()
-
-	return message
-}
 
 func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
 	decoder := realdecoder.RealDecoder{}

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -61,11 +61,6 @@ func (f *ForgottenTopic) Encode(pe *encoder.RealEncoder) {
 	pe.PutCompactInt32Array(f.Partitions)
 }
 
-type FetchRequest struct {
-	Header RequestHeader
-	Body   FetchRequestBody
-}
-
 type FetchRequestBody struct {
 	MaxWaitMS         int32
 	MinBytes          int32
@@ -105,4 +100,20 @@ func (r *FetchRequestBody) Encode(pe *encoder.RealEncoder) {
 	pe.PutCompactString(r.RackID)
 
 	pe.PutEmptyTaggedFieldArray()
+}
+
+type FetchRequest struct {
+	Header RequestHeader
+	Body   FetchRequestBody
+}
+
+func (r *FetchRequest) Encode() []byte {
+	encoder := realencoder.RealEncoder{}
+	encoder.Init(make([]byte, 4096))
+
+	r.Header.EncodeV2(&encoder)
+	r.Body.Encode(&encoder)
+	message := encoder.PackMessage()
+
+	return message
 }

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type Partition struct {
@@ -13,7 +13,7 @@ type Partition struct {
 	PartitionMaxBytes  int32 // max bytes to fetch
 }
 
-func (p *Partition) Encode(pe *encoder.RealEncoder) {
+func (p *Partition) Encode(pe *realencoder.RealEncoder) {
 	pe.PutInt32(p.ID)
 	pe.PutInt32(p.CurrentLeaderEpoch)
 	pe.PutInt64(p.FetchOffset)
@@ -28,8 +28,8 @@ type Topic struct {
 	Partitions []Partition
 }
 
-func (t *Topic) Encode(pe *encoder.RealEncoder) {
-	uuidBytes, err := encoder.EncodeUUID(t.TopicUUID)
+func (t *Topic) Encode(pe *realencoder.RealEncoder) {
+	uuidBytes, err := realencoder.EncodeUUID(t.TopicUUID)
 	if err != nil {
 		return
 	}
@@ -51,8 +51,8 @@ type ForgottenTopic struct {
 	Partitions []int32
 }
 
-func (f *ForgottenTopic) Encode(pe *encoder.RealEncoder) {
-	uuidBytes, err := encoder.EncodeUUID(f.TopicUUID)
+func (f *ForgottenTopic) Encode(pe *realencoder.RealEncoder) {
+	uuidBytes, err := realencoder.EncodeUUID(f.TopicUUID)
 	if err != nil {
 		return
 	}
@@ -73,7 +73,7 @@ type FetchRequestBody struct {
 	RackID            string
 }
 
-func (r *FetchRequestBody) Encode(pe *encoder.RealEncoder) {
+func (r *FetchRequestBody) Encode(pe *realencoder.RealEncoder) {
 	pe.PutInt32(r.MaxWaitMS)
 	pe.PutInt32(r.MinBytes)
 	pe.PutInt32(r.MaxBytes)

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,0 +1,5 @@
+package builder
+
+type RequestI interface {
+	Encode() []byte
+}

--- a/protocol/kafka_broker/broker.go
+++ b/protocol/kafka_broker/broker.go
@@ -116,6 +116,10 @@ func (b *Broker) SendAndReceive(request builder.RequestI, stageLogger *logger.Lo
 		message = req.Encode()
 		stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", req.Header.ApiVersion, req.Header.CorrelationId)
 		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
+	case *kafkaapi.DescribeTopicPartitionsRequest:
+		message = req.Encode()
+		stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", req.Header.ApiVersion, req.Header.CorrelationId)
+		stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", protocol.GetFormattedHexdump(message))
 	case *kafkaapi.FetchRequest:
 		message = req.Encode()
 		stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", req.Header.ApiVersion, req.Header.CorrelationId)
@@ -143,6 +147,8 @@ func (b *Broker) SendAndReceive(request builder.RequestI, stageLogger *logger.Lo
 	switch request.(type) {
 	case *kafkaapi.ApiVersionsRequest:
 		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
+	case *kafkaapi.DescribeTopicPartitionsRequest:
+		stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 	case *kafkaapi.FetchRequest:
 		stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", protocol.GetFormattedHexdump(response.RawBytes))
 	default:

--- a/protocol/kafka_broker/broker.go
+++ b/protocol/kafka_broker/broker.go
@@ -1,4 +1,4 @@
-package protocol
+package kafka_broker
 
 import (
 	"bytes"
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
-	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -126,14 +125,14 @@ func (b *Broker) SendAndReceive(request []byte) (Response, error) {
 func (b *Broker) SendAndReceiveNew(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
 	var message []byte
 
-	switch req := request.(type) {
-	case *kafkaapi.ApiVersionsRequest:
-		message := kafkaapi.EncodeApiVersionsRequest(req)
-		stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", req.Header.ApiVersion, req.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
-	default:
-		panic(fmt.Sprintf("CodeCrafters Internal Error: Unknown request type: %T", request))
-	}
+	// switch req := request.(type) {
+	// case *kafkaapi.ApiVersionsRequest:
+	// 	message := kafkaapi.EncodeApiVersionsRequest(req)
+	// 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", req.Header.ApiVersion, req.Header.CorrelationId)
+	// 	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", GetFormattedHexdump(message))
+	// default:
+	// 	panic(fmt.Sprintf("CodeCrafters Internal Error: Unknown request type: %T", request))
+	// }
 
 	response := Response{}
 

--- a/protocol/kafka_broker/broker.go
+++ b/protocol/kafka_broker/broker.go
@@ -108,7 +108,7 @@ func (b *Broker) Close() error {
 	return nil
 }
 
-func (b *Broker) SendAndReceiveNew(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
+func (b *Broker) SendAndReceive(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
 	var message []byte
 
 	switch req := request.(type) {

--- a/protocol/kafka_broker/broker.go
+++ b/protocol/kafka_broker/broker.go
@@ -108,22 +108,6 @@ func (b *Broker) Close() error {
 	return nil
 }
 
-func (b *Broker) SendAndReceive(request []byte) (Response, error) {
-	response := Response{}
-
-	err := b.Send(request)
-	if err != nil {
-		return response, err
-	}
-
-	response, err = b.Receive()
-	if err != nil {
-		return response, err
-	}
-
-	return response, nil
-}
-
 func (b *Broker) SendAndReceiveNew(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
 	var message []byte
 

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -18,6 +18,48 @@ func PrintHexdump(data []byte) {
 	fmt.Println()
 }
 
+func GetFormattedHexdump(data []byte) string {
+	// This is used for logs
+	// Contains headers + vertical & horizontal separators + offset
+	// We use a different format for the error logs
+	var formattedHexdump strings.Builder
+	var asciiChars strings.Builder
+
+	formattedHexdump.WriteString("Idx  | Hex                                             | ASCII\n")
+	formattedHexdump.WriteString("-----+-------------------------------------------------+-----------------\n")
+
+	for i, b := range data {
+		if i%16 == 0 && i != 0 {
+			formattedHexdump.WriteString("| " + asciiChars.String() + "\n")
+			asciiChars.Reset()
+		}
+		if i%16 == 0 {
+			formattedHexdump.WriteString(fmt.Sprintf("%04x | ", i))
+		}
+		formattedHexdump.WriteString(fmt.Sprintf("%02x ", b))
+
+		// Add ASCII representation
+		if b >= 32 && b <= 126 {
+			asciiChars.WriteByte(b)
+		} else {
+			asciiChars.WriteByte('.')
+		}
+	}
+
+	// Pad the last line if necessary
+	if len(data)%16 != 0 {
+		padding := 16 - (len(data) % 16)
+		for i := 0; i < padding; i++ {
+			formattedHexdump.WriteString("   ")
+		}
+	}
+
+	// Add the final ASCII representation
+	formattedHexdump.WriteString("| " + asciiChars.String())
+
+	return formattedHexdump.String()
+}
+
 func GetFormattedHexdumpForErrors(data []byte) string {
 	var formattedHexdump strings.Builder
 	var asciiChars strings.Builder


### PR DESCRIPTION
Extract broker-related code from `protocol` package into a dedicated `kafka_broker` package for better code organization.

**Changes:**
- Move `Broker` struct and related methods to `protocol/kafka_broker/`
- Update all stage files to use `kafka_broker.NewBroker()` instead of `protocol.NewBroker()`
- Update function signatures to use `*kafka_broker.Broker` type
- Move `GetFormattedHexdump()` calls to use `protocol.GetFormattedHexdump()`

This refactoring improves code organization by separating broker connection logic from the main protocol package.