### PR TITLE
Streamline assertions interface

### DIFF
--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -58,9 +58,9 @@ func (a *ApiVersionsResponseAssertion) AssertBody(excludedFields ...string) *Api
 	return a
 }
 
-// AssertAPIKeyArray asserts the API keys array in the response
+// AssertAPIKeysArray asserts the API keys array in the response
 // Fields asserted by default: ApiKeysArray.length, ApiKeyArrayElement.MinVersion, ApiKeyArrayElement.MaxVersion
-func (a *ApiVersionsResponseAssertion) AssertAPIKeyArray() *ApiVersionsResponseAssertion {
+func (a *ApiVersionsResponseAssertion) AssertAPIKeysArray() *ApiVersionsResponseAssertion {
 	if a.err != nil {
 		return a
 	}

--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -59,6 +59,7 @@ func (a *ApiVersionsResponseAssertion) AssertBody(excludedFields ...string) *Api
 }
 
 // AssertAPIKeyArray asserts the API keys array in the response
+// Fields asserted by default: ApiKeysArray.length, ApiKeyArrayElement.MinVersion, ApiKeyArrayElement.MaxVersion
 func (a *ApiVersionsResponseAssertion) AssertAPIKeyArray() *ApiVersionsResponseAssertion {
 	if a.err != nil {
 		return a

--- a/internal/assertions/describe_topic_partitions_response_assertion.go
+++ b/internal/assertions/describe_topic_partitions_response_assertion.go
@@ -41,7 +41,7 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertBody(excludedFields ...
 }
 
 // AssertTopics asserts the contents of the topics array in the response body
-// Fields asserted by default: ErrorCode, Name, TopicID, TopicAuthorizedOperations
+// Fields asserted by default: ErrorCode, Name, TopicID
 func (a *DescribeTopicPartitionsResponseAssertion) AssertTopics(excludedFields ...string) *DescribeTopicPartitionsResponseAssertion {
 	if a.err != nil {
 		return a
@@ -131,7 +131,7 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertPartitions(excludedFiel
 		}
 	}
 
-	return nil
+	return a
 }
 
 // AssertNoPartitions asserts that for each topicResponse in the response body,
@@ -150,7 +150,7 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertNoPartitions() *Describ
 		}
 	}
 
-	return nil
+	return a
 }
 
 func (a *DescribeTopicPartitionsResponseAssertion) Run() error {

--- a/internal/assertions/describe_topic_partitions_response_assertion.go
+++ b/internal/assertions/describe_topic_partitions_response_assertion.go
@@ -40,12 +40,12 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertBody(excludedFields ...
 	return a
 }
 
-// AssertTopics asserts the contents of the topics array in the response body
+// AssertTopicsAndPartitions asserts the contents of the topics array in the response body
 // Fields asserted by default: ErrorCode, Name, TopicID,
 // Partitions.Length, Partitions.ErrorCode, Partitions.PartitionIndex
 // As we want partition assertions logs adjacent to the topics they are in,
 // we can't separate AssertPartitions out
-func (a *DescribeTopicPartitionsResponseAssertion) AssertTopics(excludedFields ...string) *DescribeTopicPartitionsResponseAssertion {
+func (a *DescribeTopicPartitionsResponseAssertion) AssertTopicsAndPartitions(excludedFields ...string) *DescribeTopicPartitionsResponseAssertion {
 	if a.err != nil {
 		return a
 	}
@@ -112,45 +112,6 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertTopics(excludedFields .
 			}
 
 			if !Contains(excludedFields, "Partition.PartitionIndex") {
-				if actualPartition.PartitionIndex != expectedPartition.PartitionIndex {
-					a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Partition Index", j), expectedPartition.PartitionIndex, actualPartition.PartitionIndex)
-					return a
-				}
-				protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Partition Index: %d", j, actualPartition.PartitionIndex)
-			}
-		}
-	}
-
-	return a
-}
-
-// assertPartitions asserts the contents of the partitions array in the topic response
-// Fields asserted by default: ErrorCode, PartitionIndex
-func (a *DescribeTopicPartitionsResponseAssertion) assertPartitions(excludedFields ...string) *DescribeTopicPartitionsResponseAssertion {
-	for i, actualTopic := range a.ActualValue.Topics {
-		expectedTopic := a.ExpectedValue.Topics[i]
-
-		expectedPartitions := expectedTopic.Partitions
-		actualPartitions := actualTopic.Partitions
-
-		// TODO: Add topic index ?
-		if len(actualPartitions) != len(expectedPartitions) {
-			a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
-			return a
-		}
-
-		for j, actualPartition := range actualPartitions {
-			expectedPartition := expectedPartitions[j]
-
-			if !Contains(excludedFields, "ErrorCode") {
-				if actualPartition.ErrorCode != expectedPartition.ErrorCode {
-					a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
-					return a
-				}
-				protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d", j, actualPartition.ErrorCode)
-			}
-
-			if !Contains(excludedFields, "PartitionIndex") {
 				if actualPartition.PartitionIndex != expectedPartition.PartitionIndex {
 					a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Partition Index", j), expectedPartition.PartitionIndex, actualPartition.PartitionIndex)
 					return a

--- a/internal/assertions/describe_topic_partitions_response_assertion.go
+++ b/internal/assertions/describe_topic_partitions_response_assertion.go
@@ -97,13 +97,12 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertTopicsAndPartitions(exc
 				a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
 				return a
 			}
-			protocol.SuccessLogWithIndentation(a.logger, 1, "✓ TopicResponse[%d] Partitions Length: %d", i, len(actualPartitions))
 		}
 
 		for j, actualPartition := range actualPartitions {
 			expectedPartition := expectedPartitions[j]
 
-			if !Contains(excludedFields, "Partition.ErrorCode") {
+			if !Contains(excludedFields, "Partitions.ErrorCode") {
 				if actualPartition.ErrorCode != expectedPartition.ErrorCode {
 					a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
 					return a
@@ -111,7 +110,7 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertTopicsAndPartitions(exc
 				protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d", j, actualPartition.ErrorCode)
 			}
 
-			if !Contains(excludedFields, "Partition.PartitionIndex") {
+			if !Contains(excludedFields, "Partitions.PartitionIndex") {
 				if actualPartition.PartitionIndex != expectedPartition.PartitionIndex {
 					a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Partition Index", j), expectedPartition.PartitionIndex, actualPartition.PartitionIndex)
 					return a
@@ -122,6 +121,11 @@ func (a *DescribeTopicPartitionsResponseAssertion) AssertTopicsAndPartitions(exc
 	}
 
 	return a
+}
+
+func (a *DescribeTopicPartitionsResponseAssertion) AssertOnlyTopics(excludedFields ...string) *DescribeTopicPartitionsResponseAssertion {
+	excludedFieldsAndPartitions := append(excludedFields, "Partitions.Length", "Partitions.ErrorCode", "Partitions.PartitionIndex")
+	return a.AssertTopicsAndPartitions(excludedFieldsAndPartitions...)
 }
 
 // AssertNoPartitions asserts that for each topicResponse in the response body,

--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -250,7 +250,7 @@ func (a *FetchResponseAssertion) AssertRecordBatchBytes() *FetchResponseAssertio
 		result := bytes_diff_visualizer.VisualizeByteDiff(expectedRecordBatchBytes, actualRecordBatchBytes)
 		a.logger.Errorf("")
 		for _, line := range result {
-			a.logger.Errorf(line)
+			a.logger.Errorf("%s", line)
 		}
 		a.logger.Errorf("")
 		a.err = fmt.Errorf("RecordBatch bytes do not match with the contents on disk")

--- a/internal/assertions/response_header_assertion.go
+++ b/internal/assertions/response_header_assertion.go
@@ -24,7 +24,7 @@ func NewResponseHeaderAssertion(actualValue kafkaapi.ResponseHeader, expectedVal
 
 // AssertHeader asserts the contents of the response header
 // Fields asserted by default: CorrelationId
-func (a *ResponseHeaderAssertion) AssertHeader(excludedFields []string) *ResponseHeaderAssertion {
+func (a *ResponseHeaderAssertion) AssertHeader(excludedFields ...string) *ResponseHeaderAssertion {
 	if a.err != nil {
 		return a
 	}

--- a/internal/assertions/response_header_assertion.go
+++ b/internal/assertions/response_header_assertion.go
@@ -22,12 +22,14 @@ func NewResponseHeaderAssertion(actualValue kafkaapi.ResponseHeader, expectedVal
 	}
 }
 
-func (a *ResponseHeaderAssertion) AssertHeader(fields []string) *ResponseHeaderAssertion {
+// AssertHeader asserts the contents of the response header
+// Fields asserted by default: CorrelationId
+func (a *ResponseHeaderAssertion) AssertHeader(excludedFields []string) *ResponseHeaderAssertion {
 	if a.err != nil {
 		return a
 	}
 
-	if Contains(fields, "CorrelationId") {
+	if !Contains(excludedFields, "CorrelationId") {
 		if a.ActualValue.CorrelationId != a.ExpectedValue.CorrelationId {
 			a.err = fmt.Errorf("Expected %s to be %d, got %d", "CorrelationId", a.ExpectedValue.CorrelationId, a.ActualValue.CorrelationId)
 			return a

--- a/internal/assertions/utils.go
+++ b/internal/assertions/utils.go
@@ -1,11 +1,8 @@
 package assertions
 
+import "slices"
+
 // Contains checks if a target string exists within the slice.
 func Contains(slice []string, target string) bool {
-	for _, item := range slice {
-		if item == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, target)
 }

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -79,7 +79,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeyArray().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -79,7 +79,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeyArray().Run(); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeysArray().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -58,7 +58,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -80,7 +80,6 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody().
-		AssertTopics().
-		AssertPartitions().
+		AssertOnlyTopics().
 		Run()
 }

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -79,7 +79,8 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
-		AssertBody([]string{"ThrottleTimeMs"}).
-		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
+		AssertBody().
+		AssertTopics().
+		AssertPartitions().
 		Run()
 }

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -62,7 +62,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -89,7 +89,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
-		AssertBody([]string{"ThrottleTimeMs"}).
-		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{}).
+		AssertBody().
+		AssertTopics().
 		Run()
 }

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -90,6 +90,6 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody().
-		AssertTopics().
+		AssertOnlyTopics().
 		Run()
 }

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -61,7 +61,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -102,7 +102,6 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody().
-		AssertTopics().
-		AssertPartitions().
+		AssertTopicsAndPartitions().
 		Run()
 }

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -61,7 +61,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -101,7 +101,8 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
-		AssertBody([]string{"ThrottleTimeMs"}).
-		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{"ErrorCode", "PartitionIndex"}).
+		AssertBody().
+		AssertTopics().
+		AssertPartitions().
 		Run()
 }

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -146,7 +146,6 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
 		AssertBody().
-		AssertTopics().
-		AssertPartitions().
+		AssertTopicsAndPartitions().
 		Run()
 }

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -69,7 +69,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -145,7 +145,8 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}
 
 	return assertions.NewDescribeTopicPartitionsResponseAssertion(*responseBody, expectedDescribeTopicPartitionsResponse, stageLogger).
-		AssertBody([]string{"ThrottleTimeMs"}).
-		AssertTopics([]string{"ErrorCode", "Name", "TopicID"}, []string{"ErrorCode", "PartitionIndex"}).
+		AssertBody().
+		AssertTopics().
+		AssertPartitions().
 		Run()
 }

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -80,7 +80,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeyArray().Run(); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeysArray().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -80,7 +80,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse, stageLogger).AssertBody().AssertAPIKeyArray().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -59,7 +59,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -63,7 +63,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -81,7 +81,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -78,7 +78,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -78,7 +78,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).AssertHeader().Run(); err != nil {
 		return err
 	}
 

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -78,7 +78,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	expectedResponseHeader := kafkaapi.ResponseHeader{
 		CorrelationId: correlationId,
 	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, logger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).AssertHeader().Run(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Summary

  - Refactored assertion methods to use variadic parameters eliminating the need for empty []string{} arrays
  - Separated assertion concerns into focused methods (e.g., AssertBody() and AssertAPIKeyArray())
  - Enhanced logging and error handling across assertion classes
  - Improved utility functions using Go's slices package

# Key Changes

  - Cleaner API: Updated ResponseHeaderAssertion, ApiVersionsResponseAssertion, and DescribeTopicPartitionsResponseAssertion
  to use ...string variadic parameters
  - Method Separation: Split complex assertion methods into focused functions following the pattern from
  FetchResponseAssertion
  - Utility Improvements: Simplified Contains function using slices.Contains from Go's standard library
  - Enhanced Logging: Improved debug logging for byte differences and assertion results