### PR TITLE
Update sendAndReceive signature to accept structs and not pointers to structs

### DIFF
--- a/internal/assertions/fetch_response_assertion.go
+++ b/internal/assertions/fetch_response_assertion.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/tester-utils/bytes_diff_visualizer"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -275,7 +275,7 @@ func encodeRecordBatches(recordBatches []kafkaapi.RecordBatch) []byte {
 	// Given an array of RecordBatch, encodes them using the encoder.RealEncoder
 	// and returns the resulting bytes.
 
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 	for _, recordBatch := range recordBatches {
 		recordBatch.Encode(&encoder)

--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"fmt"
 
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
@@ -65,7 +65,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 	}
 	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	stageLogger.UpdateSecondaryPrefix("Decoder")
 

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/codecrafters-io/tester-utils/logger"
 
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
@@ -66,7 +66,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	stageLogger.UpdateSecondaryPrefix("Decoder")
 

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -8,7 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -66,7 +66,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	}
 	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", protocol.GetFormattedHexdump(response))
 
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	stageLogger.UpdateSecondaryPrefix("Decoder")
 

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -47,7 +47,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -51,7 +51,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		}
 
 		stageLogger.Infof("Sending request %d of %d:", i+1, requestCount)
-		response, err := client.SendAndReceive(&request, stageLogger)
+		response, err := client.SendAndReceive(request, stageLogger)
 		if err != nil {
 			return err
 		}

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -45,7 +45,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -49,7 +49,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -48,7 +48,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -48,7 +48,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -56,7 +56,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -46,7 +46,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -50,7 +50,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -68,7 +68,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, stageLogger)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -65,7 +65,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, logger)
+	response, err := client.SendAndReceive(request, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -65,7 +65,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, logger)
+	response, err := client.SendAndReceive(request, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -65,7 +65,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	response, err := client.SendAndReceive(&request, logger)
+	response, err := client.SendAndReceive(request, logger)
 	if err != nil {
 		return err
 	}

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -8,11 +8,13 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
+// EncodeApiVersionsRequest are going to be removed
+// TODO: Use Request.Encode instead much cleaner.
 func EncodeApiVersionsRequest(request *ApiVersionsRequest) []byte {
 	encoder := realencoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
-	request.Header.EncodeV2(&encoder)
+	request.Header.Encode(&encoder)
 	request.Body.Encode(&encoder)
 	messageBytes := encoder.PackMessage()
 

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -1,8 +1,8 @@
 package kafkaapi
 
 import (
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -11,7 +11,7 @@ import (
 // EncodeApiVersionsRequest are going to be removed
 // TODO: Use Request.Encode instead much cleaner.
 func EncodeApiVersionsRequest(request *ApiVersionsRequest) []byte {
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
 	request.Header.Encode(&encoder)
@@ -22,7 +22,7 @@ func EncodeApiVersionsRequest(request *ApiVersionsRequest) []byte {
 }
 
 func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	logger.UpdateSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefix()
@@ -43,7 +43,7 @@ func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logg
 // DecodeApiVersionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil
 func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ApiVersionsResponse, error) {
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	logger.UpdateSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefix()

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type ApiVersionsRequestBody struct {
@@ -13,7 +13,7 @@ type ApiVersionsRequestBody struct {
 	ClientSoftwareVersion string
 }
 
-func (r ApiVersionsRequestBody) Encode(enc *realencoder.RealEncoder) {
+func (r ApiVersionsRequestBody) Encode(enc *encoder.RealEncoder) {
 	if r.Version >= 3 {
 		enc.PutCompactString(r.ClientSoftwareName)
 		enc.PutCompactString(r.ClientSoftwareVersion)
@@ -27,7 +27,7 @@ type ApiVersionsRequest struct {
 }
 
 func (r ApiVersionsRequest) Encode() []byte {
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
 	r.Header.Encode(&encoder)

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -13,7 +13,7 @@ type ApiVersionsRequestBody struct {
 	ClientSoftwareVersion string
 }
 
-func (r *ApiVersionsRequestBody) Encode(enc *realencoder.RealEncoder) {
+func (r ApiVersionsRequestBody) Encode(enc *realencoder.RealEncoder) {
 	if r.Version >= 3 {
 		enc.PutCompactString(r.ClientSoftwareName)
 		enc.PutCompactString(r.ClientSoftwareVersion)
@@ -26,27 +26,25 @@ type ApiVersionsRequest struct {
 	Body   ApiVersionsRequestBody
 }
 
-// Encode doesn't need to accept a pointer to the request
-// TODO: We are not modifying the request, internally, so we can remove the pointer
-func (r *ApiVersionsRequest) Encode() []byte {
+func (r ApiVersionsRequest) Encode() []byte {
 	encoder := realencoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
-	r.Header.EncodeV2(&encoder)
+	r.Header.Encode(&encoder)
 	r.Body.Encode(&encoder)
 	messageBytes := encoder.PackMessage()
 
 	return messageBytes
 }
 
-func (r *ApiVersionsRequest) GetApiType() string {
+func (r ApiVersionsRequest) GetApiType() string {
 	return "ApiVersions"
 }
 
-func (r *ApiVersionsRequest) GetApiVersion() int16 {
+func (r ApiVersionsRequest) GetApiVersion() int16 {
 	return r.Header.ApiVersion
 }
 
-func (r *ApiVersionsRequest) GetCorrelationId() int32 {
+func (r ApiVersionsRequest) GetCorrelationId() int32 {
 	return r.Header.CorrelationId
 }

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -9,7 +9,7 @@ import (
 // DecodeDescribeTopicPartitionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil
 func DecodeDescribeTopicPartitionsHeaderAndResponse(response []byte, logger *logger.Logger) (*ResponseHeader, *DescribeTopicPartitionsResponse, error) {
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	logger.UpdateSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefix()

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type DescribeTopicPartitionsRequestBody struct {
@@ -10,7 +10,7 @@ type DescribeTopicPartitionsRequestBody struct {
 	Cursor                 Cursor
 }
 
-func (r *DescribeTopicPartitionsRequestBody) Encode(pe *realencoder.RealEncoder) {
+func (r *DescribeTopicPartitionsRequestBody) Encode(pe *encoder.RealEncoder) {
 	// Encode topics array length
 	pe.PutCompactArrayLength(len(r.Topics))
 
@@ -36,7 +36,7 @@ type TopicName struct {
 	Name string
 }
 
-func (t *TopicName) Encode(pe *realencoder.RealEncoder) {
+func (t *TopicName) Encode(pe *encoder.RealEncoder) {
 	pe.PutCompactString(t.Name)
 	pe.PutEmptyTaggedFieldArray()
 }
@@ -46,7 +46,7 @@ type Cursor struct {
 	PartitionIndex int32
 }
 
-func (c *Cursor) Encode(pe *realencoder.RealEncoder) {
+func (c *Cursor) Encode(pe *encoder.RealEncoder) {
 	pe.PutCompactString(c.TopicName)
 	pe.PutInt32(c.PartitionIndex)
 	pe.PutEmptyTaggedFieldArray()
@@ -58,7 +58,7 @@ type DescribeTopicPartitionsRequest struct {
 }
 
 func (r DescribeTopicPartitionsRequest) Encode() []byte {
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
 	r.Header.Encode(&encoder)

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -57,11 +57,11 @@ type DescribeTopicPartitionsRequest struct {
 	Body   DescribeTopicPartitionsRequestBody
 }
 
-func (r *DescribeTopicPartitionsRequest) Encode() []byte {
+func (r DescribeTopicPartitionsRequest) Encode() []byte {
 	encoder := realencoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
-	r.Header.EncodeV2(&encoder)
+	r.Header.Encode(&encoder)
 	r.Body.Encode(&encoder)
 	messageBytes := encoder.PackMessage()
 
@@ -69,14 +69,14 @@ func (r *DescribeTopicPartitionsRequest) Encode() []byte {
 
 }
 
-func (r *DescribeTopicPartitionsRequest) GetApiType() string {
+func (r DescribeTopicPartitionsRequest) GetApiType() string {
 	return "DescribeTopicPartitions"
 }
 
-func (r *DescribeTopicPartitionsRequest) GetApiVersion() int16 {
+func (r DescribeTopicPartitionsRequest) GetApiVersion() int16 {
 	return r.Header.ApiVersion
 }
 
-func (r *DescribeTopicPartitionsRequest) GetCorrelationId() int32 {
+func (r DescribeTopicPartitionsRequest) GetCorrelationId() int32 {
 	return r.Header.CorrelationId
 }

--- a/protocol/api/describe_topic_partitions_response.go
+++ b/protocol/api/describe_topic_partitions_response.go
@@ -16,7 +16,7 @@ type DescribeTopicPartitionsResponse struct {
 	NextCursor     DescribeTopicPartitionsResponseCursor
 }
 
-func (a DescribeTopicPartitionsResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (a *DescribeTopicPartitionsResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	a.ThrottleTimeMs, err = pd.GetInt32()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -78,7 +78,7 @@ type DescribeTopicPartitionsResponseTopic struct {
 	TopicAuthorizedOperations int32
 }
 
-func (a DescribeTopicPartitionsResponseTopic) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (a *DescribeTopicPartitionsResponseTopic) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	a.ErrorCode, err = pd.GetInt16()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -179,7 +179,7 @@ type DescribeTopicPartitionsResponsePartition struct {
 	OfflineReplicas        []int32
 }
 
-func (d DescribeTopicPartitionsResponsePartition) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (d *DescribeTopicPartitionsResponsePartition) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	d.ErrorCode, err = pd.GetInt16()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -280,7 +280,7 @@ func (c DescribeTopicPartitionsResponseCursor) String() string {
 	return fmt.Sprintf("{TopicName: %s, PartitionIndex: %d}", c.TopicName, c.PartitionIndex)
 }
 
-func (c DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) error {
+func (c *DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) error {
 	var err error
 
 	// This field is nullable, the first byte indicates whether it's null or not
@@ -295,7 +295,7 @@ func (c DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, l
 
 	if checkPresence == -1 {
 		protocol.LogWithIndentation(logger, indentation, "- .next_cursor (null)")
-		c = DescribeTopicPartitionsResponseCursor{}
+		c = nil
 		return nil
 	} else {
 		protocol.LogWithIndentation(logger, indentation, "- .next_cursor")

--- a/protocol/api/describe_topic_partitions_response.go
+++ b/protocol/api/describe_topic_partitions_response.go
@@ -16,7 +16,7 @@ type DescribeTopicPartitionsResponse struct {
 	NextCursor     DescribeTopicPartitionsResponseCursor
 }
 
-func (a *DescribeTopicPartitionsResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (a DescribeTopicPartitionsResponse) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	a.ThrottleTimeMs, err = pd.GetInt32()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -78,7 +78,7 @@ type DescribeTopicPartitionsResponseTopic struct {
 	TopicAuthorizedOperations int32
 }
 
-func (a *DescribeTopicPartitionsResponseTopic) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (a DescribeTopicPartitionsResponseTopic) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	a.ErrorCode, err = pd.GetInt16()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -179,7 +179,7 @@ type DescribeTopicPartitionsResponsePartition struct {
 	OfflineReplicas        []int32
 }
 
-func (d *DescribeTopicPartitionsResponsePartition) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
+func (d DescribeTopicPartitionsResponsePartition) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) (err error) {
 	d.ErrorCode, err = pd.GetInt16()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -280,7 +280,7 @@ func (c DescribeTopicPartitionsResponseCursor) String() string {
 	return fmt.Sprintf("{TopicName: %s, PartitionIndex: %d}", c.TopicName, c.PartitionIndex)
 }
 
-func (c *DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) error {
+func (c DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, logger *logger.Logger, indentation int) error {
 	var err error
 
 	// This field is nullable, the first byte indicates whether it's null or not
@@ -295,7 +295,7 @@ func (c *DescribeTopicPartitionsResponseCursor) Decode(pd *decoder.RealDecoder, 
 
 	if checkPresence == -1 {
 		protocol.LogWithIndentation(logger, indentation, "- .next_cursor (null)")
-		c = nil
+		c = DescribeTopicPartitionsResponseCursor{}
 		return nil
 	} else {
 		protocol.LogWithIndentation(logger, indentation, "- .next_cursor")

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -1,14 +1,14 @@
 package kafkaapi
 
 import (
-	realdecoder "github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
 func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	logger.UpdateSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefix()
@@ -27,7 +27,7 @@ func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*
 }
 
 func DecodeFetchHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *FetchResponse, error) {
-	decoder := realdecoder.RealDecoder{}
+	decoder := decoder.RealDecoder{}
 	decoder.Init(response)
 	logger.UpdateSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefix()

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type Partition struct {
@@ -13,7 +13,7 @@ type Partition struct {
 	PartitionMaxBytes  int32 // max bytes to fetch
 }
 
-func (p *Partition) Encode(pe *realencoder.RealEncoder) {
+func (p *Partition) Encode(pe *encoder.RealEncoder) {
 	pe.PutInt32(p.ID)
 	pe.PutInt32(p.CurrentLeaderEpoch)
 	pe.PutInt64(p.FetchOffset)
@@ -28,8 +28,8 @@ type Topic struct {
 	Partitions []Partition
 }
 
-func (t *Topic) Encode(pe *realencoder.RealEncoder) {
-	uuidBytes, err := realencoder.EncodeUUID(t.TopicUUID)
+func (t *Topic) Encode(pe *encoder.RealEncoder) {
+	uuidBytes, err := encoder.EncodeUUID(t.TopicUUID)
 	if err != nil {
 		return
 	}
@@ -51,8 +51,8 @@ type ForgottenTopic struct {
 	Partitions []int32
 }
 
-func (f *ForgottenTopic) Encode(pe *realencoder.RealEncoder) {
-	uuidBytes, err := realencoder.EncodeUUID(f.TopicUUID)
+func (f *ForgottenTopic) Encode(pe *encoder.RealEncoder) {
+	uuidBytes, err := encoder.EncodeUUID(f.TopicUUID)
 	if err != nil {
 		return
 	}
@@ -73,7 +73,7 @@ type FetchRequestBody struct {
 	RackID            string
 }
 
-func (r *FetchRequestBody) Encode(pe *realencoder.RealEncoder) {
+func (r *FetchRequestBody) Encode(pe *encoder.RealEncoder) {
 	pe.PutInt32(r.MaxWaitMS)
 	pe.PutInt32(r.MinBytes)
 	pe.PutInt32(r.MaxBytes)
@@ -108,7 +108,7 @@ type FetchRequest struct {
 }
 
 func (r FetchRequest) Encode() []byte {
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
 	r.Header.Encode(&encoder)

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -107,25 +107,25 @@ type FetchRequest struct {
 	Body   FetchRequestBody
 }
 
-func (r *FetchRequest) Encode() []byte {
+func (r FetchRequest) Encode() []byte {
 	encoder := realencoder.RealEncoder{}
 	encoder.Init(make([]byte, 4096))
 
-	r.Header.EncodeV2(&encoder)
+	r.Header.Encode(&encoder)
 	r.Body.Encode(&encoder)
 	message := encoder.PackMessage()
 
 	return message
 }
 
-func (r *FetchRequest) GetApiType() string {
+func (r FetchRequest) GetApiType() string {
 	return "Fetch"
 }
 
-func (r *FetchRequest) GetApiVersion() int16 {
+func (r FetchRequest) GetApiVersion() int16 {
 	return r.Header.ApiVersion
 }
 
-func (r *FetchRequest) GetCorrelationId() int32 {
+func (r FetchRequest) GetCorrelationId() int32 {
 	return r.Header.CorrelationId
 }

--- a/protocol/api/header.go
+++ b/protocol/api/header.go
@@ -20,7 +20,11 @@ type RequestHeader struct {
 	ClientId string
 }
 
-func (h *RequestHeader) EncodeV2(enc *encoder.RealEncoder) {
+func (h RequestHeader) Encode(enc *encoder.RealEncoder) {
+	h.encodeV2(enc)
+}
+
+func (h RequestHeader) encodeV2(enc *encoder.RealEncoder) {
 	enc.PutInt16(h.ApiKey)
 	enc.PutInt16(h.ApiVersion)
 	enc.PutInt32(h.CorrelationId)

--- a/protocol/api/record_batch.go
+++ b/protocol/api/record_batch.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	realencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -27,7 +27,7 @@ type RecordBatch struct {
 	Records              []Record
 }
 
-func (rb *RecordBatch) Encode(pe *realencoder.RealEncoder) {
+func (rb *RecordBatch) Encode(pe *encoder.RealEncoder) {
 	startOffset := pe.Offset()
 
 	pe.PutInt64(rb.BaseOffset)
@@ -210,7 +210,7 @@ type Record struct {
 	Headers        []RecordHeader
 }
 
-func (r *Record) Encode(pe *realencoder.RealEncoder) {
+func (r *Record) Encode(pe *encoder.RealEncoder) {
 	pe.PutVarint(int64(r.GetEncodedLength())) // Length placeholder
 	// As this is variable length, we can't use placeholders and update later reliably.
 	// We need to have a value, close to the actual value, such that it takes the same space
@@ -232,7 +232,7 @@ func (r *Record) Encode(pe *realencoder.RealEncoder) {
 }
 
 func (r *Record) GetEncodedLength() int {
-	encoder := realencoder.RealEncoder{}
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 1024))
 
 	encoder.PutInt8(r.Attributes)
@@ -363,7 +363,7 @@ type RecordHeader struct {
 	Value []byte
 }
 
-func (rh *RecordHeader) Encode(pe *realencoder.RealEncoder) {
+func (rh *RecordHeader) Encode(pe *encoder.RealEncoder) {
 	pe.PutVarint(int64(len(rh.Key)))
 	pe.PutBytes([]byte(rh.Key))
 	pe.PutVarint(int64(len(rh.Value)))

--- a/protocol/serializer/utils.go
+++ b/protocol/serializer/utils.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	kafkaencoder "github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/google/uuid"
 )
 
-func GetEncodedBytes(encodableObject interface{}) []byte {
-	encoder := kafkaencoder.RealEncoder{}
+func GetEncodedBytes(encodableObject any) []byte {
+	encoder := encoder.RealEncoder{}
 	encoder.Init(make([]byte, 1024))
 
 	switch obj := encodableObject.(type) {


### PR DESCRIPTION
- Updated Encode methods in ApiVersionsRequest, DescribeTopicPartitionsRequest, and FetchRequest to accept values instead of pointers, improving code consistency and readability.
- Adjusted related methods in DescribeTopicPartitionsResponse and RequestHeader to align with this change, enhancing overall code clarity and maintainability.