### PR TITLE
Simplify Request interface to only return Header()

### DIFF
--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -37,14 +37,6 @@ func (r ApiVersionsRequest) Encode() []byte {
 	return messageBytes
 }
 
-func (r ApiVersionsRequest) GetApiType() string {
-	return "ApiVersions"
-}
-
-func (r ApiVersionsRequest) GetApiVersion() int16 {
-	return r.Header.ApiVersion
-}
-
-func (r ApiVersionsRequest) GetCorrelationId() int32 {
-	return r.Header.CorrelationId
+func (r ApiVersionsRequest) GetHeader() RequestHeader {
+	return r.Header
 }

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -69,14 +69,6 @@ func (r DescribeTopicPartitionsRequest) Encode() []byte {
 
 }
 
-func (r DescribeTopicPartitionsRequest) GetApiType() string {
-	return "DescribeTopicPartitions"
-}
-
-func (r DescribeTopicPartitionsRequest) GetApiVersion() int16 {
-	return r.Header.ApiVersion
-}
-
-func (r DescribeTopicPartitionsRequest) GetCorrelationId() int32 {
-	return r.Header.CorrelationId
+func (r DescribeTopicPartitionsRequest) GetHeader() RequestHeader {
+	return r.Header
 }

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -118,14 +118,6 @@ func (r FetchRequest) Encode() []byte {
 	return message
 }
 
-func (r FetchRequest) GetApiType() string {
-	return "Fetch"
-}
-
-func (r FetchRequest) GetApiVersion() int16 {
-	return r.Header.ApiVersion
-}
-
-func (r FetchRequest) GetCorrelationId() int32 {
-	return r.Header.CorrelationId
+func (r FetchRequest) GetHeader() RequestHeader {
+	return r.Header
 }

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,8 +1,8 @@
 package builder
 
+import kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+
 type RequestI interface {
 	Encode() []byte
-	GetApiType() string
-	GetApiVersion() int16
-	GetCorrelationId() int32
+	GetHeader() kafkaapi.RequestHeader
 }

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -109,9 +109,10 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) SendAndReceive(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
-	apiType := request.GetApiType()
-	apiVersion := request.GetApiVersion()
-	correlationId := request.GetCorrelationId()
+	header := request.GetHeader()
+	apiType := protocol.APIKeyToName(header.ApiKey)
+	apiVersion := header.ApiVersion
+	correlationId := header.CorrelationId
 	message := request.Encode()
 
 	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiType, apiVersion, correlationId)

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -108,7 +108,7 @@ func APIKeyToName(apiKey int16) string {
 	case 1:
 		return "Fetch"
 	case 18:
-		return "APIVersions"
+		return "ApiVersions"
 	case 19:
 		return "CreateTopics"
 	case 75:

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -114,6 +114,6 @@ func APIKeyToName(apiKey int16) string {
 	case 75:
 		return "DescribeTopicPartitions"
 	default:
-		return "Unknown"
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Unknown API key: %v", apiKey))
 	}
 }

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -100,3 +100,20 @@ func LogWithIndentation(logger *logger.Logger, indentation int, message string, 
 func SuccessLogWithIndentation(logger *logger.Logger, indentation int, message string, args ...interface{}) {
 	logger.Successf(fmt.Sprintf("%s%s", strings.Repeat(" ", indentation*2), message), args...)
 }
+
+func APIKeyToName(apiKey int16) string {
+	switch apiKey {
+	case 0:
+		return "Produce"
+	case 1:
+		return "Fetch"
+	case 18:
+		return "APIVersions"
+	case 19:
+		return "CreateTopics"
+	case 75:
+		return "DescribeTopicPartitions"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
- Introduced APIKeyToName function in utils.go to provide a mapping from integer API keys to their corresponding string names, enhancing code readability and usability for API interactions.