### PR TITLE
Add requestbody and requestHeader interfaces and simplify Encode() on request

### DIFF
--- a/internal/assertions/response_header_assertion.go
+++ b/internal/assertions/response_header_assertion.go
@@ -3,13 +3,13 @@ package assertions
 import (
 	"fmt"
 
-	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
 type ResponseHeaderAssertion struct {
-	ActualValue   kafkaapi.ResponseHeader
-	ExpectedValue kafkaapi.ResponseHeader
+	ActualValue   headers.ResponseHeader
+	ExpectedValue headers.ResponseHeader
 	logger        *logger.Logger
 	err           error
 
@@ -18,7 +18,7 @@ type ResponseHeaderAssertion struct {
 	excludedHeaderFields []string
 }
 
-func NewResponseHeaderAssertion(actualValue kafkaapi.ResponseHeader, expectedValue kafkaapi.ResponseHeader, logger *logger.Logger) *ResponseHeaderAssertion {
+func NewResponseHeaderAssertion(actualValue headers.ResponseHeader, expectedValue headers.ResponseHeader, logger *logger.Logger) *ResponseHeaderAssertion {
 	return &ResponseHeaderAssertion{
 		ActualValue:          actualValue,
 		ExpectedValue:        expectedValue,

--- a/internal/fetch_test.go
+++ b/internal/fetch_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +24,7 @@ func TestFetchv16With0Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := kafkaapi.ResponseHeader{}
+	header := headers.ResponseHeader{}
 
 	if err = header.DecodeV1(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -66,7 +68,7 @@ func TestFetchv16With1Message(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := kafkaapi.ResponseHeader{}
+	header := headers.ResponseHeader{}
 
 	if err = header.DecodeV1(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -119,7 +121,7 @@ func TestFetchv16With2Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := kafkaapi.ResponseHeader{}
+	header := headers.ResponseHeader{}
 
 	if err = header.DecodeV1(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -169,7 +171,7 @@ func TestFetchv16With3Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := kafkaapi.ResponseHeader{}
+	header := headers.ResponseHeader{}
 
 	if err = header.DecodeV1(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -218,7 +220,7 @@ func TestAPIVersionv3(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	responseHeader := kafkaapi.ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	if err := responseHeader.DecodeV0(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
 		return

--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -37,7 +38,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 	correlationId := 7
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    4,
 			CorrelationId: int32(correlationId),

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -39,7 +40,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	correlationId := getRandomCorrelationId()
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    4,
 			CorrelationId: correlationId,

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -39,7 +40,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	}(client)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    int16(apiVersion),
 			CorrelationId: correlationId,

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -33,7 +34,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	}(client)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    4,
 			CorrelationId: correlationId,
@@ -56,7 +57,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/random"
@@ -37,7 +38,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	for i := range requestCount {
 		correlationId := getRandomCorrelationId()
 		request := kafkaapi.ApiVersionsRequest{
-			Header: kafkaapi.RequestHeader{
+			Header: headers.RequestHeader{
 				ApiKey:        18,
 				ApiVersion:    4,
 				CorrelationId: correlationId,

--- a/internal/stage_c2.go
+++ b/internal/stage_c2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -48,7 +49,7 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	for i, client := range clients {
 		correlationIds[i] = int32(random.RandomInt(-math.MaxInt32, math.MaxInt32))
 		request := kafkaapi.ApiVersionsRequest{
-			Header: kafkaapi.RequestHeader{
+			Header: headers.RequestHeader{
 				ApiKey:        18,
 				ApiVersion:    4,
 				CorrelationId: correlationIds[i],

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -32,7 +33,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	}(client)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    4,
 			CorrelationId: correlationId,
@@ -55,7 +56,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -33,7 +34,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}(client)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
@@ -59,7 +60,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}(client)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
@@ -58,7 +59,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}(client)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
@@ -58,7 +59,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}(client)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        75,
 			ApiVersion:    0,
 			CorrelationId: correlationId,
@@ -66,7 +67,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -33,7 +34,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	}(client)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        18,
 			ApiVersion:    4,
 			CorrelationId: correlationId,
@@ -56,7 +57,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -31,7 +32,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	}(client)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        1,
 			ApiVersion:    16,
 			CorrelationId: correlationId,
@@ -60,7 +61,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -35,7 +36,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 	}(client)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        1,
 			ApiVersion:    16,
 			CorrelationId: correlationId,
@@ -78,7 +79,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, stageLogger).Run(); err != nil {

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	}(client)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        1,
 			ApiVersion:    16,
 			CorrelationId: correlationId,
@@ -75,7 +76,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).Run(); err != nil {

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	}(client)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        1,
 			ApiVersion:    16,
 			CorrelationId: correlationId,
@@ -75,7 +76,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).Run(); err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -4,6 +4,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -32,7 +33,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	}(client)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
+		Header: headers.RequestHeader{
 			ApiKey:        1,
 			ApiVersion:    16,
 			CorrelationId: correlationId,
@@ -75,7 +76,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
+	expectedResponseHeader := headers.ResponseHeader{
 		CorrelationId: correlationId,
 	}
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader, logger).Run(); err != nil {

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 )
 
 // EncodeApiVersionsRequest are going to be removed
@@ -21,13 +22,13 @@ func EncodeApiVersionsRequest(request *ApiVersionsRequest) []byte {
 	return messageBytes
 }
 
-func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
+func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	// APIVersions always uses Header v0
 	if err := responseHeader.DecodeV0(&decoder, logger, 1); err != nil {
@@ -42,13 +43,13 @@ func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logg
 
 // DecodeApiVersionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil
-func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ApiVersionsResponse, error) {
+func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, *ApiVersionsResponse, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.DecodeV0(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
@@ -25,7 +26,7 @@ func (r ApiVersionsRequestBody) Encode(enc *encoder.Encoder) {
 }
 
 type ApiVersionsRequest struct {
-	Header RequestHeader
+	Header headers.RequestHeader
 	Body   ApiVersionsRequestBody
 }
 
@@ -33,7 +34,7 @@ func (r ApiVersionsRequest) Encode() []byte {
 	return encodeRequest(r)
 }
 
-func (r ApiVersionsRequest) GetHeader() builder.RequestHeaderI {
+func (r ApiVersionsRequest) GetHeader() headers.RequestHeader {
 	return r.Header
 }
 

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -15,11 +15,13 @@ type ApiVersionsRequestBody struct {
 }
 
 func (r ApiVersionsRequestBody) Encode(enc *encoder.Encoder) {
-	if r.Version >= 3 {
-		enc.PutCompactString(r.ClientSoftwareName)
-		enc.PutCompactString(r.ClientSoftwareVersion)
-		enc.PutEmptyTaggedFieldArray()
+	if r.Version < 3 {
+		panic("CodeCrafers Internal Error: ApiVersionsRequestBody.Version must be >= 3")
 	}
+
+	enc.PutCompactString(r.ClientSoftwareName)
+	enc.PutCompactString(r.ClientSoftwareVersion)
+	enc.PutEmptyTaggedFieldArray()
 }
 
 type ApiVersionsRequest struct {

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
@@ -37,6 +38,10 @@ func (r ApiVersionsRequest) Encode() []byte {
 	return messageBytes
 }
 
-func (r ApiVersionsRequest) GetHeader() RequestHeader {
+func (r ApiVersionsRequest) GetHeader() builder.RequestHeaderI {
 	return r.Header
+}
+
+func (r ApiVersionsRequest) GetBody() builder.RequestBodyI {
+	return r.Body
 }

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -30,14 +30,7 @@ type ApiVersionsRequest struct {
 }
 
 func (r ApiVersionsRequest) Encode() []byte {
-	encoder := encoder.Encoder{}
-	encoder.Init(make([]byte, 4096))
-
-	r.Header.Encode(&encoder)
-	r.Body.Encode(&encoder)
-	messageBytes := encoder.PackMessage()
-
-	return messageBytes
+	return encodeRequest(r)
 }
 
 func (r ApiVersionsRequest) GetHeader() builder.RequestHeaderI {

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -4,17 +4,18 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 )
 
 // DecodeDescribeTopicPartitionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil
-func DecodeDescribeTopicPartitionsHeaderAndResponse(response []byte, logger *logger.Logger) (*ResponseHeader, *DescribeTopicPartitionsResponse, error) {
+func DecodeDescribeTopicPartitionsHeaderAndResponse(response []byte, logger *logger.Logger) (*headers.ResponseHeader, *DescribeTopicPartitionsResponse, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -11,7 +11,7 @@ type DescribeTopicPartitionsRequestBody struct {
 	Cursor                 Cursor
 }
 
-func (r *DescribeTopicPartitionsRequestBody) Encode(pe *encoder.Encoder) {
+func (r DescribeTopicPartitionsRequestBody) Encode(pe *encoder.Encoder) {
 	// Encode topics array length
 	pe.PutCompactArrayLength(len(r.Topics))
 
@@ -37,7 +37,7 @@ type TopicName struct {
 	Name string
 }
 
-func (t *TopicName) Encode(pe *encoder.Encoder) {
+func (t TopicName) Encode(pe *encoder.Encoder) {
 	pe.PutCompactString(t.Name)
 	pe.PutEmptyTaggedFieldArray()
 }
@@ -47,7 +47,7 @@ type Cursor struct {
 	PartitionIndex int32
 }
 
-func (c *Cursor) Encode(pe *encoder.Encoder) {
+func (c Cursor) Encode(pe *encoder.Encoder) {
 	pe.PutCompactString(c.TopicName)
 	pe.PutInt32(c.PartitionIndex)
 	pe.PutEmptyTaggedFieldArray()

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
@@ -54,7 +55,7 @@ func (c Cursor) Encode(pe *encoder.Encoder) {
 }
 
 type DescribeTopicPartitionsRequest struct {
-	Header RequestHeader
+	Header headers.RequestHeader
 	Body   DescribeTopicPartitionsRequestBody
 }
 
@@ -62,7 +63,7 @@ func (r DescribeTopicPartitionsRequest) Encode() []byte {
 	return encodeRequest(r)
 }
 
-func (r DescribeTopicPartitionsRequest) GetHeader() builder.RequestHeaderI {
+func (r DescribeTopicPartitionsRequest) GetHeader() headers.RequestHeader {
 	return r.Header
 }
 

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
@@ -69,6 +70,10 @@ func (r DescribeTopicPartitionsRequest) Encode() []byte {
 
 }
 
-func (r DescribeTopicPartitionsRequest) GetHeader() RequestHeader {
+func (r DescribeTopicPartitionsRequest) GetHeader() builder.RequestHeaderI {
 	return r.Header
+}
+
+func (r DescribeTopicPartitionsRequest) GetBody() builder.RequestBodyI {
+	return r.Body
 }

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -59,15 +59,7 @@ type DescribeTopicPartitionsRequest struct {
 }
 
 func (r DescribeTopicPartitionsRequest) Encode() []byte {
-	encoder := encoder.Encoder{}
-	encoder.Init(make([]byte, 4096))
-
-	r.Header.Encode(&encoder)
-	r.Body.Encode(&encoder)
-	messageBytes := encoder.PackMessage()
-
-	return messageBytes
-
+	return encodeRequest(r)
 }
 
 func (r DescribeTopicPartitionsRequest) GetHeader() builder.RequestHeaderI {

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -1,18 +1,19 @@
 package kafkaapi
 
 import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
+func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -25,13 +26,13 @@ func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*
 	return &responseHeader, nil
 }
 
-func DecodeFetchHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *FetchResponse, error) {
+func DecodeFetchHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, *FetchResponse, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := ResponseHeader{}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -109,14 +109,7 @@ type FetchRequest struct {
 }
 
 func (r FetchRequest) Encode() []byte {
-	encoder := encoder.Encoder{}
-	encoder.Init(make([]byte, 4096))
-
-	r.Header.Encode(&encoder)
-	r.Body.Encode(&encoder)
-	message := encoder.PackMessage()
-
-	return message
+	return encodeRequest(r)
 }
 
 func (r FetchRequest) GetHeader() builder.RequestHeaderI {

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
@@ -104,7 +105,7 @@ func (r FetchRequestBody) Encode(pe *encoder.Encoder) {
 }
 
 type FetchRequest struct {
-	Header RequestHeader
+	Header headers.RequestHeader
 	Body   FetchRequestBody
 }
 
@@ -112,7 +113,7 @@ func (r FetchRequest) Encode() []byte {
 	return encodeRequest(r)
 }
 
-func (r FetchRequest) GetHeader() builder.RequestHeaderI {
+func (r FetchRequest) GetHeader() headers.RequestHeader {
 	return r.Header
 }
 

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -14,7 +14,7 @@ type Partition struct {
 	PartitionMaxBytes  int32 // max bytes to fetch
 }
 
-func (p *Partition) Encode(pe *encoder.Encoder) {
+func (p Partition) Encode(pe *encoder.Encoder) {
 	pe.PutInt32(p.ID)
 	pe.PutInt32(p.CurrentLeaderEpoch)
 	pe.PutInt64(p.FetchOffset)
@@ -29,7 +29,7 @@ type Topic struct {
 	Partitions []Partition
 }
 
-func (t *Topic) Encode(pe *encoder.Encoder) {
+func (t Topic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(t.TopicUUID)
 	if err != nil {
 		return
@@ -52,7 +52,7 @@ type ForgottenTopic struct {
 	Partitions []int32
 }
 
-func (f *ForgottenTopic) Encode(pe *encoder.Encoder) {
+func (f ForgottenTopic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(f.TopicUUID)
 	if err != nil {
 		return
@@ -74,7 +74,7 @@ type FetchRequestBody struct {
 	RackID            string
 }
 
-func (r *FetchRequestBody) Encode(pe *encoder.Encoder) {
+func (r FetchRequestBody) Encode(pe *encoder.Encoder) {
 	pe.PutInt32(r.MaxWaitMS)
 	pe.PutInt32(r.MinBytes)
 	pe.PutInt32(r.MaxBytes)

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -1,6 +1,7 @@
 package kafkaapi
 
 import (
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
@@ -118,6 +119,10 @@ func (r FetchRequest) Encode() []byte {
 	return message
 }
 
-func (r FetchRequest) GetHeader() RequestHeader {
+func (r FetchRequest) GetHeader() builder.RequestHeaderI {
 	return r.Header
+}
+
+func (r FetchRequest) GetBody() builder.RequestBodyI {
+	return r.Body
 }

--- a/protocol/api/header.go
+++ b/protocol/api/header.go
@@ -20,6 +20,18 @@ type RequestHeader struct {
 	ClientId string
 }
 
+func (h RequestHeader) GetApiKey() int16 {
+	return h.ApiKey
+}
+
+func (h RequestHeader) GetApiVersion() int16 {
+	return h.ApiVersion
+}
+
+func (h RequestHeader) GetCorrelationId() int32 {
+	return h.CorrelationId
+}
+
 func (h RequestHeader) Encode(enc *encoder.Encoder) {
 	h.encodeV2(enc)
 }

--- a/protocol/api/headers/request_header.go
+++ b/protocol/api/headers/request_header.go
@@ -1,0 +1,29 @@
+package kafkaapi
+
+import (
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+)
+
+// RequestHeader defines the header for a Kafka request
+type RequestHeader struct {
+	// ApiKey defines the API key for the request
+	ApiKey int16
+	// ApiVersion defines the API version for the request
+	ApiVersion int16
+	// CorrelationId defines the correlation ID for the request
+	CorrelationId int32
+	// ClientId defines the client ID for the request
+	ClientId string
+}
+
+func (h RequestHeader) Encode(enc *encoder.Encoder) {
+	h.encodeV2(enc)
+}
+
+func (h RequestHeader) encodeV2(enc *encoder.Encoder) {
+	enc.PutInt16(h.ApiKey)
+	enc.PutInt16(h.ApiVersion)
+	enc.PutInt32(h.CorrelationId)
+	enc.PutString(h.ClientId)
+	enc.PutEmptyTaggedFieldArray()
+}

--- a/protocol/api/headers/response_header.go
+++ b/protocol/api/headers/response_header.go
@@ -3,51 +3,17 @@ package kafkaapi
 import (
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
-
-// RequestHeader defines the header for a Kafka request
-type RequestHeader struct {
-	// ApiKey defines the API key for the request
-	ApiKey int16
-	// ApiVersion defines the API version for the request
-	ApiVersion int16
-	// CorrelationId defines the correlation ID for the request
-	CorrelationId int32
-	// ClientId defines the client ID for the request
-	ClientId string
-}
-
-func (h RequestHeader) GetApiKey() int16 {
-	return h.ApiKey
-}
-
-func (h RequestHeader) GetApiVersion() int16 {
-	return h.ApiVersion
-}
-
-func (h RequestHeader) GetCorrelationId() int32 {
-	return h.CorrelationId
-}
-
-func (h RequestHeader) Encode(enc *encoder.Encoder) {
-	h.encodeV2(enc)
-}
-
-func (h RequestHeader) encodeV2(enc *encoder.Encoder) {
-	enc.PutInt16(h.ApiKey)
-	enc.PutInt16(h.ApiVersion)
-	enc.PutInt32(h.CorrelationId)
-	enc.PutString(h.ClientId)
-	enc.PutEmptyTaggedFieldArray()
-}
 
 // ResponseHeader defines the header for a Kafka response
 type ResponseHeader struct {
 	CorrelationId int32
 }
+
+// TODO: Add version to struct, and based on that decide which internal function to call
+// Expose only Decode()
 
 func (h *ResponseHeader) DecodeV0(decoder *decoder.Decoder, logger *logger.Logger, indentation int) error {
 	correlation_id, err := decoder.GetInt32()

--- a/protocol/api/request.go
+++ b/protocol/api/request.go
@@ -1,0 +1,16 @@
+package kafkaapi
+
+import (
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+)
+
+func encodeRequest(req builder.RequestI) []byte {
+	encoder := encoder.Encoder{}
+	encoder.Init(make([]byte, 4096))
+
+	req.GetHeader().Encode(&encoder)
+	req.GetBody().Encode(&encoder)
+
+	return encoder.PackMessage()
+}

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,20 +1,18 @@
 package builder
 
 import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
 type RequestI interface {
 	Encode() []byte
 	GetBody() RequestBodyI
-	GetHeader() RequestHeaderI
+	GetHeader() headers.RequestHeader
 }
 
 type RequestHeaderI interface {
 	Encode(pe *encoder.Encoder)
-	GetApiKey() int16
-	GetApiVersion() int16
-	GetCorrelationId() int32
 }
 
 type RequestBodyI interface {

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,10 +1,24 @@
 package builder
 
-import kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+import (
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+)
 
 type RequestI interface {
 	Encode() []byte
-	GetHeader() kafkaapi.RequestHeader
+	GetBody() RequestBodyI
+	GetHeader() RequestHeaderI
+}
+
+type RequestHeaderI interface {
+	Encode(pe *encoder.Encoder)
+	GetApiKey() int16
+	GetApiVersion() int16
+	GetCorrelationId() int32
+}
+
+type RequestBodyI interface {
+	Encode(pe *encoder.Encoder)
 }
 
 // TODO

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -110,9 +110,9 @@ func (c *Client) Close() error {
 
 func (c *Client) SendAndReceive(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
 	header := request.GetHeader()
-	apiType := protocol.APIKeyToName(header.GetApiKey())
-	apiVersion := header.GetApiVersion()
-	correlationId := header.GetCorrelationId()
+	apiType := protocol.APIKeyToName(header.ApiKey)
+	apiVersion := header.ApiVersion
+	correlationId := header.CorrelationId
 	message := request.Encode()
 
 	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiType, apiVersion, correlationId)

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -110,9 +110,9 @@ func (c *Client) Close() error {
 
 func (c *Client) SendAndReceive(request builder.RequestI, stageLogger *logger.Logger) (Response, error) {
 	header := request.GetHeader()
-	apiType := protocol.APIKeyToName(header.ApiKey)
-	apiVersion := header.ApiVersion
-	correlationId := header.CorrelationId
+	apiType := protocol.APIKeyToName(header.GetApiKey())
+	apiVersion := header.GetApiVersion()
+	correlationId := header.GetCorrelationId()
 	message := request.Encode()
 
 	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiType, apiVersion, correlationId)


### PR DESCRIPTION
- Changed the test command in local_testing/test.sh to run 'make test' instead of 'make test_all' for more focused testing.
- Updated the SendAndReceive method in kafka_client to use getter methods for ApiKey, ApiVersion, and CorrelationId, enhancing encapsulation and code clarity.