### PR TITLE
Add `RequestHeaderBuilder` and simplify header constructions

### DIFF
--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -33,15 +34,10 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 		_ = broker.Close()
 	}(broker)
 
-	correlationId := 7
+	correlationId := int32(7)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    4,
-			CorrelationId: int32(correlationId),
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -37,12 +38,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 	correlationId := getRandomCorrelationId()
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    4,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -8,6 +8,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -38,12 +39,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    int16(apiVersion),
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().WithApiKey(18).WithApiVersion(int16(apiVersion)).WithCorrelationId(correlationId).Build(),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -6,6 +6,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -34,12 +35,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    4,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -2,11 +2,13 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/codecrafters-io/tester-utils/logger"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -36,12 +38,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	for i := 0; i < requestCount; i++ {
 		correlationId := getRandomCorrelationId()
 		request := kafkaapi.ApiVersionsRequest{
-			Header: kafkaapi.RequestHeader{
-				ApiKey:        18,
-				ApiVersion:    4,
-				CorrelationId: correlationId,
-				ClientId:      "kafka-cli",
-			},
+			Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 			Body: kafkaapi.ApiVersionsRequestBody{
 				Version:               4,
 				ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_c2.go
+++ b/internal/stage_c2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/random"
@@ -47,12 +48,7 @@ func testConcurrentRequests(stageHarness *test_case_harness.TestCaseHarness) err
 	for i, client := range clients {
 		correlationIds[i] = int32(random.RandomInt(-math.MaxInt32, math.MaxInt32))
 		request := kafkaapi.ApiVersionsRequest{
-			Header: kafkaapi.RequestHeader{
-				ApiKey:        18,
-				ApiVersion:    4,
-				CorrelationId: correlationIds[i],
-				ClientId:      "kafka-cli",
-			},
+			Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationIds[i]),
 			Body: kafkaapi.ApiVersionsRequestBody{
 				Version:               4,
 				ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    4,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -33,12 +34,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        75,
-			ApiVersion:    0,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-tester",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildDescribeTopicPartitionsRequestHeader(correlationId),
 		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        75,
-			ApiVersion:    0,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-tester",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildDescribeTopicPartitionsRequestHeader(correlationId),
 		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        75,
-			ApiVersion:    0,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-tester",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildDescribeTopicPartitionsRequestHeader(correlationId),
 		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	}(broker)
 
 	request := kafkaapi.DescribeTopicPartitionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        75,
-			ApiVersion:    0,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-tester",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildDescribeTopicPartitionsRequestHeader(correlationId),
 		Body: kafkaapi.DescribeTopicPartitionsRequestBody{
 			Topics: []kafkaapi.TopicName{
 				{

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -33,12 +34,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        18,
-			ApiVersion:    4,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -34,7 +34,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	}(broker)
 
 	request := kafkaapi.ApiVersionsRequest{
-		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
+		Header: builder.NewRequestHeaderBuilder().BuildApiVersionsRequestHeader(correlationId),
 		Body: kafkaapi.ApiVersionsRequestBody{
 			Version:               4,
 			ClientSoftwareName:    "kafka-cli",

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -31,12 +32,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	}(broker)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        1,
-			ApiVersion:    16,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-tester",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.FetchRequestBody{
 			MaxWaitMS:         500,
 			MinBytes:          1,

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -35,12 +36,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 	}(broker)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        1,
-			ApiVersion:    16,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.FetchRequestBody{
 			MaxWaitMS:         500,
 			MinBytes:          1,

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	}(broker)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        1,
-			ApiVersion:    16,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.FetchRequestBody{
 			MaxWaitMS:         500,
 			MinBytes:          1,

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	}(broker)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        1,
-			ApiVersion:    16,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.FetchRequestBody{
 			MaxWaitMS:         500,
 			MinBytes:          1,

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -5,6 +5,7 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	"github.com/codecrafters-io/kafka-tester/protocol"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -32,12 +33,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	}(broker)
 
 	request := kafkaapi.FetchRequest{
-		Header: kafkaapi.RequestHeader{
-			ApiKey:        1,
-			ApiVersion:    16,
-			CorrelationId: correlationId,
-			ClientId:      "kafka-cli",
-		},
+		Header: builder.NewRequestHeaderBuilder().BuildFetchRequestHeader(correlationId),
 		Body: kafkaapi.FetchRequestBody{
 			MaxWaitMS:         500,
 			MinBytes:          1,

--- a/protocol/builder/request_header_builder.go
+++ b/protocol/builder/request_header_builder.go
@@ -1,0 +1,53 @@
+package builder
+
+import kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+
+type RequestHeaderBuilder struct {
+	apiKey        int16
+	apiVersion    int16
+	correlationId int32
+}
+
+func NewRequestHeaderBuilder() *RequestHeaderBuilder {
+	return &RequestHeaderBuilder{
+		apiKey:        0,
+		apiVersion:    0,
+		correlationId: 0,
+	}
+}
+
+func (b *RequestHeaderBuilder) WithApiKey(apiKey int16) *RequestHeaderBuilder {
+	b.apiKey = apiKey
+	return b
+}
+
+func (b *RequestHeaderBuilder) WithApiVersion(apiVersion int16) *RequestHeaderBuilder {
+	b.apiVersion = apiVersion
+	return b
+}
+
+func (b *RequestHeaderBuilder) WithCorrelationId(correlationId int32) *RequestHeaderBuilder {
+	b.correlationId = correlationId
+	return b
+}
+
+func (b *RequestHeaderBuilder) Build() kafkaapi.RequestHeader {
+	return kafkaapi.RequestHeader{
+		ApiKey:        b.apiKey,
+		ApiVersion:    b.apiVersion,
+		CorrelationId: b.correlationId,
+		ClientId:      "kafka-tester",
+	}
+}
+
+func (b *RequestHeaderBuilder) BuildProduceRequestHeader(correlationId int32) kafkaapi.RequestHeader {
+	return b.WithApiKey(0).WithApiVersion(11).WithCorrelationId(correlationId).Build()
+}
+
+func (b *RequestHeaderBuilder) BuildFetchRequestHeader(correlationId int32) kafkaapi.RequestHeader {
+	return b.WithApiKey(1).WithApiVersion(16).WithCorrelationId(correlationId).Build()
+}
+
+func (b *RequestHeaderBuilder) NewApiVersionsRequestHeader(correlationId int32) *RequestHeaderBuilder {
+	return b.WithApiKey(18).WithApiVersion(4).WithCorrelationId(correlationId)
+}

--- a/protocol/builder/request_header_builder.go
+++ b/protocol/builder/request_header_builder.go
@@ -51,3 +51,7 @@ func (b *RequestHeaderBuilder) BuildFetchRequestHeader(correlationId int32) kafk
 func (b *RequestHeaderBuilder) BuildApiVersionsRequestHeader(correlationId int32) kafkaapi.RequestHeader {
 	return b.WithApiKey(18).WithApiVersion(4).WithCorrelationId(correlationId).Build()
 }
+
+func (b *RequestHeaderBuilder) BuildDescribeTopicPartitionsRequestHeader(correlationId int32) kafkaapi.RequestHeader {
+	return b.WithApiKey(75).WithApiVersion(0).WithCorrelationId(correlationId).Build()
+}

--- a/protocol/builder/request_header_builder.go
+++ b/protocol/builder/request_header_builder.go
@@ -48,6 +48,6 @@ func (b *RequestHeaderBuilder) BuildFetchRequestHeader(correlationId int32) kafk
 	return b.WithApiKey(1).WithApiVersion(16).WithCorrelationId(correlationId).Build()
 }
 
-func (b *RequestHeaderBuilder) NewApiVersionsRequestHeader(correlationId int32) *RequestHeaderBuilder {
-	return b.WithApiKey(18).WithApiVersion(4).WithCorrelationId(correlationId)
+func (b *RequestHeaderBuilder) BuildApiVersionsRequestHeader(correlationId int32) kafkaapi.RequestHeader {
+	return b.WithApiKey(18).WithApiVersion(4).WithCorrelationId(correlationId).Build()
 }


### PR DESCRIPTION
- Added RequestHeaderBuilder to standardize Kafka request header construction with customizable API key, version, and correlation ID.
- Introduced specific header building methods for Produce, Fetch, ApiVersions, and DescribeTopicPartitions requests.
- Refactored multiple request header constructions (FetchRequest, ApiVersionsRequest, DescribeTopicPartitionsRequest) to use RequestHeaderBuilder, improving consistency and maintainability.
- Renamed NewApiVersionsRequestHeader to BuildApiVersionsRequestHeader for clarity and uniformity.
- Fixed ApiVersionsRequest header construction to use the correct builder method for accuracy.