### PR TITLE
Add `ApiVersionsResponseBuilder` and some usages

### DIFF
--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -8,11 +8,11 @@ import (
 )
 
 type ApiVersionsResponseAssertion struct {
-	ActualValue   kafkaapi.ApiVersionsResponse
-	ExpectedValue kafkaapi.ApiVersionsResponse
+	ActualValue   kafkaapi.ApiVersionsResponseBody
+	ExpectedValue kafkaapi.ApiVersionsResponseBody
 }
 
-func NewApiVersionsResponseAssertion(actualValue kafkaapi.ApiVersionsResponse, expectedValue kafkaapi.ApiVersionsResponse) ApiVersionsResponseAssertion {
+func NewApiVersionsResponseAssertion(actualValue kafkaapi.ApiVersionsResponseBody, expectedValue kafkaapi.ApiVersionsResponseBody) ApiVersionsResponseAssertion {
 	return ApiVersionsResponseAssertion{ActualValue: actualValue, ExpectedValue: expectedValue}
 }
 

--- a/internal/fetch_test.go
+++ b/internal/fetch_test.go
@@ -224,7 +224,7 @@ func TestAPIVersionv3(t *testing.T) {
 		return
 	}
 
-	apiVersionsResponse := kafkaapi.ApiVersionsResponse{Version: 3}
+	apiVersionsResponse := kafkaapi.ApiVersionsResponseBody{Version: 3}
 	if err := apiVersionsResponse.Decode(&decoder, 3, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
 		return

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -90,7 +90,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 	errorCode, err := decoder.GetInt16()
 	if err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-			err = decodingErr.WithAddedContext("errorCode").WithAddedContext("ApiVersionsResponse")
+			err = decodingErr.WithAddedContext("errorCode").WithAddedContext("ApiVersionsResponseBody")
 			return decoder.FormatDetailedError(err.Error())
 		}
 		return err

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -63,23 +63,12 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		return err
 	}
 
-	expectedApiVersionResponse := kafkaapi.ApiVersionsResponse{
-		Version:   3,
-		ErrorCode: 0,
-		ApiKeys: []kafkaapi.ApiVersionsResponseKey{
-			{
-				ApiKey:     18,
-				MaxVersion: 4,
-				MinVersion: 0,
-			},
-			{
-				ApiKey:     75,
-				MaxVersion: 0,
-				MinVersion: 0,
-			},
-		},
-	}
+	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
+		AddApiKeyVersionSupport(18, 4, 0).
+		AddApiKeyVersionSupport(75, 0, 0).
+		Build(correlationId)
 
+	// TODO: Add ApiVersionsResponseAssertion to all stages
 	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -57,8 +57,8 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	}
 
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
-		AddApiKeyVersionSupport(18, 0, 4).
-		AddApiKeyVersionSupport(75, 0, 0).
+		AddApiKeyEntry(18, 0, 4).
+		AddApiKeyEntry(75, 0, 0).
 		Build(correlationId)
 
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedApiVersionResponse.Header).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -64,7 +64,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	}
 
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
-		AddApiKeyVersionSupport(18, 4, 0).
+		AddApiKeyVersionSupport(18, 0, 4).
 		AddApiKeyVersionSupport(75, 0, 0).
 		Build(correlationId)
 

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -56,20 +56,17 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
-		CorrelationId: correlationId,
-	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
-		return err
-	}
-
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
 		AddApiKeyVersionSupport(18, 0, 4).
 		AddApiKeyVersionSupport(75, 0, 0).
 		Build(correlationId)
 
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedApiVersionResponse.Header).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+		return err
+	}
+
 	// TODO: Add ApiVersionsResponseAssertion to all stages
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse.Body).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
 		return err
 	}
 

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -58,8 +58,8 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	}
 
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
-		AddApiKeyVersionSupport(1, 0, 16).
-		AddApiKeyVersionSupport(18, 0, 4).
+		AddApiKeyEntry(1, 0, 16).
+		AddApiKeyEntry(18, 0, 4).
 		Build(correlationId)
 
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedApiVersionResponse.Header).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -66,7 +66,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
 		AddApiKeyVersionSupport(1, 0, 16).
-		AddApiKeyVersionSupport(18, 4, 0).
+		AddApiKeyVersionSupport(18, 0, 4).
 		Build(correlationId)
 
 	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -57,19 +57,16 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	expectedResponseHeader := kafkaapi.ResponseHeader{
-		CorrelationId: correlationId,
-	}
-	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
-		return err
-	}
-
 	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
 		AddApiKeyVersionSupport(1, 0, 16).
 		AddApiKeyVersionSupport(18, 0, 4).
 		Build(correlationId)
 
-	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
+	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedApiVersionResponse.Header).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
+		return err
+	}
+
+	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse.Body).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
 		return err
 	}
 

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -64,22 +64,10 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	expectedApiVersionResponse := kafkaapi.ApiVersionsResponse{
-		Version:   3,
-		ErrorCode: 0,
-		ApiKeys: []kafkaapi.ApiVersionsResponseKey{
-			{
-				ApiKey:     1,
-				MaxVersion: 16,
-				MinVersion: 0,
-			},
-			{
-				ApiKey:     18,
-				MaxVersion: 4,
-				MinVersion: 0,
-			},
-		},
-	}
+	expectedApiVersionResponse := builder.NewApiVersionsResponseBuilder().
+		AddApiKeyVersionSupport(1, 0, 16).
+		AddApiKeyVersionSupport(18, 4, 0).
+		Build(correlationId)
 
 	if err = assertions.NewApiVersionsResponseAssertion(*responseBody, expectedApiVersionResponse).Evaluate([]string{"ErrorCode"}, true, stageLogger); err != nil {
 		return err

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -40,7 +40,7 @@ func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logg
 
 // DecodeApiVersionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil
-func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ApiVersionsResponse, error) {
+func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ApiVersionsResponseBody, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)
 	logger.UpdateLastSecondaryPrefix("Decoder")
@@ -56,7 +56,7 @@ func DecodeApiVersionsHeaderAndResponse(response []byte, version int16, logger *
 		return nil, nil, err
 	}
 
-	apiVersionsResponse := ApiVersionsResponse{Version: version}
+	apiVersionsResponse := ApiVersionsResponseBody{Version: version}
 	logger.Debugf("- .ResponseBody")
 	if err := apiVersionsResponse.Decode(&decoder, version, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/api_versions_response.go
+++ b/protocol/api/api_versions_response.go
@@ -9,8 +9,8 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-// ApiKeyVersionSupport contains the APIs supported by the broker.
-type ApiKeyVersionSupport struct {
+// ApiKeyEntry contains the APIs supported by the broker.
+type ApiKeyEntry struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
 	// ApiKey contains the API index.
@@ -21,7 +21,7 @@ type ApiKeyVersionSupport struct {
 	MaxVersion int16
 }
 
-func (a *ApiKeyVersionSupport) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
+func (a *ApiKeyEntry) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
 	a.Version = version
 	if a.ApiKey, err = pd.GetInt16(); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -66,7 +66,7 @@ type ApiVersionsResponseBody struct {
 	// ErrorCode contains the top-level error code.
 	ErrorCode int16
 	// ApiKeys contains the APIs supported by the broker.
-	ApiKeys []ApiKeyVersionSupport
+	ApiKeys []ApiKeyEntry
 	// ThrottleTimeMs contains the duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
 	ThrottleTimeMs int32
 }
@@ -105,17 +105,17 @@ func (r *ApiVersionsResponseBody) Decode(pd *decoder.Decoder, version int16, log
 		return errors.NewPacketDecodingError(fmt.Sprintf("Count of ApiKeys cannot be negative: %d", numApiKeys))
 	}
 
-	r.ApiKeys = make([]ApiKeyVersionSupport, numApiKeys)
+	r.ApiKeys = make([]ApiKeyEntry, numApiKeys)
 	for i := 0; i < numApiKeys; i++ {
-		var block ApiKeyVersionSupport
+		var apiKeyEntry ApiKeyEntry
 		protocol.LogWithIndentation(logger, indentation, "- .ApiKeys[%d]", i)
-		if err = block.Decode(pd, r.Version, logger, indentation+1); err != nil {
+		if err = apiKeyEntry.Decode(pd, r.Version, logger, indentation+1); err != nil {
 			if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-				return decodingErr.WithAddedContext(fmt.Sprintf("ApiKeyVersionSupport[%d]", i))
+				return decodingErr.WithAddedContext(fmt.Sprintf("ApiKeyEntry[%d]", i))
 			}
 			return err
 		}
-		r.ApiKeys[i] = block
+		r.ApiKeys[i] = apiKeyEntry
 	}
 
 	if r.Version >= 1 {

--- a/protocol/api/api_versions_response.go
+++ b/protocol/api/api_versions_response.go
@@ -60,7 +60,7 @@ func (a *ApiKeyVersionSupport) Decode(pd *decoder.Decoder, version int16, logger
 	return nil
 }
 
-type ApiVersionsResponse struct {
+type ApiVersionsResponseBody struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
 	// ErrorCode contains the top-level error code.
@@ -71,7 +71,7 @@ type ApiVersionsResponse struct {
 	ThrottleTimeMs int32
 }
 
-func (r *ApiVersionsResponse) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
+func (r *ApiVersionsResponseBody) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
 	r.Version = version
 	if r.ErrorCode, err = pd.GetInt16(); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -140,8 +140,13 @@ func (r *ApiVersionsResponse) Decode(pd *decoder.Decoder, version int16, logger 
 
 	// Check if there are any remaining bytes in the decoder
 	if pd.Remaining() != 0 {
-		return errors.NewPacketDecodingError(fmt.Sprintf("unexpected %d bytes remaining in decoder after decoding ApiVersionsResponse", pd.Remaining()))
+		return errors.NewPacketDecodingError(fmt.Sprintf("unexpected %d bytes remaining in decoder after decoding ApiVersionsResponseBody", pd.Remaining()))
 	}
 
 	return nil
+}
+
+type ApiVersionsResponse struct {
+	Header ResponseHeader
+	Body   ApiVersionsResponseBody
 }

--- a/protocol/api/api_versions_response.go
+++ b/protocol/api/api_versions_response.go
@@ -9,8 +9,8 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-// ApiVersionsResponseKey contains the APIs supported by the broker.
-type ApiVersionsResponseKey struct {
+// ApiKeyVersionSupport contains the APIs supported by the broker.
+type ApiKeyVersionSupport struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
 	// ApiKey contains the API index.
@@ -21,7 +21,7 @@ type ApiVersionsResponseKey struct {
 	MaxVersion int16
 }
 
-func (a *ApiVersionsResponseKey) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
+func (a *ApiKeyVersionSupport) Decode(pd *decoder.Decoder, version int16, logger *logger.Logger, indentation int) (err error) {
 	a.Version = version
 	if a.ApiKey, err = pd.GetInt16(); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -66,7 +66,7 @@ type ApiVersionsResponse struct {
 	// ErrorCode contains the top-level error code.
 	ErrorCode int16
 	// ApiKeys contains the APIs supported by the broker.
-	ApiKeys []ApiVersionsResponseKey
+	ApiKeys []ApiKeyVersionSupport
 	// ThrottleTimeMs contains the duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
 	ThrottleTimeMs int32
 }
@@ -105,13 +105,13 @@ func (r *ApiVersionsResponse) Decode(pd *decoder.Decoder, version int16, logger 
 		return errors.NewPacketDecodingError(fmt.Sprintf("Count of ApiKeys cannot be negative: %d", numApiKeys))
 	}
 
-	r.ApiKeys = make([]ApiVersionsResponseKey, numApiKeys)
+	r.ApiKeys = make([]ApiKeyVersionSupport, numApiKeys)
 	for i := 0; i < numApiKeys; i++ {
-		var block ApiVersionsResponseKey
+		var block ApiKeyVersionSupport
 		protocol.LogWithIndentation(logger, indentation, "- .ApiKeys[%d]", i)
 		if err = block.Decode(pd, r.Version, logger, indentation+1); err != nil {
 			if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-				return decodingErr.WithAddedContext(fmt.Sprintf("ApiVersionsResponseKey[%d]", i))
+				return decodingErr.WithAddedContext(fmt.Sprintf("ApiKeyVersionSupport[%d]", i))
 			}
 			return err
 		}

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -20,11 +20,6 @@ func NewApiVersionsResponseBuilder() *ApiVersionsResponseBuilder {
 	}
 }
 
-func (b *ApiVersionsResponseBuilder) WithVersion(version int16) *ApiVersionsResponseBuilder {
-	b.version = version
-	return b
-}
-
 func (b *ApiVersionsResponseBuilder) WithErrorCode(errorCode int16) *ApiVersionsResponseBuilder {
 	b.errorCode = errorCode
 	return b

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -55,7 +55,7 @@ func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVers
 			Version:        b.version,
 			ErrorCode:      b.errorCode,
 			ApiKeys:        b.apiKeys,
-			ThrottleTimeMs: 0,
+			ThrottleTimeMs: b.throttleTimeMs,
 		},
 	}
 }

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -43,7 +43,8 @@ func (b *ApiVersionsResponseBuilder) AddApiKeyVersionSupport(apiKey int16, minVe
 	return b
 }
 
-// Build should return whole response, create ApiVersionsResponse and ApiVersionsResponseBody
+// Build should return whole response
+// TODO: create separate ApiVersionsResponse and ApiVersionsResponseBody
 func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVersionsResponse {
 	return kafkaapi.ApiVersionsResponse{
 		Version:        b.version,

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -43,6 +43,7 @@ func (b *ApiVersionsResponseBuilder) AddApiKeyVersionSupport(apiKey int16, minVe
 	return b
 }
 
+// Build should return whole response, create ApiVersionsResponse and ApiVersionsResponseBody
 func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVersionsResponse {
 	return kafkaapi.ApiVersionsResponse{
 		Version:        b.version,

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -1,0 +1,53 @@
+package builder
+
+import kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+
+type ApiVersionsResponseBuilder struct {
+	version        int16
+	errorCode      int16
+	apiKeys        []kafkaapi.ApiKeyVersionSupport
+	throttleTimeMs int32
+}
+
+func NewApiVersionsResponseBuilder() *ApiVersionsResponseBuilder {
+	return &ApiVersionsResponseBuilder{
+		version:        3,
+		errorCode:      0,
+		throttleTimeMs: 0,
+		apiKeys:        []kafkaapi.ApiKeyVersionSupport{},
+	}
+}
+
+func (b *ApiVersionsResponseBuilder) WithVersion(version int16) *ApiVersionsResponseBuilder {
+	b.version = version
+	return b
+}
+
+func (b *ApiVersionsResponseBuilder) WithErrorCode(errorCode int16) *ApiVersionsResponseBuilder {
+	b.errorCode = errorCode
+	return b
+}
+
+func (b *ApiVersionsResponseBuilder) WithThrottleTimeMs(throttleTimeMs int32) *ApiVersionsResponseBuilder {
+	b.throttleTimeMs = throttleTimeMs
+	return b
+}
+
+func (b *ApiVersionsResponseBuilder) AddApiKeyVersionSupport(apiKey int16, minVersion int16, maxVersion int16) *ApiVersionsResponseBuilder {
+	b.apiKeys = append(b.apiKeys, kafkaapi.ApiKeyVersionSupport{
+		Version:    b.version,
+		ApiKey:     apiKey,
+		MinVersion: minVersion,
+		MaxVersion: maxVersion,
+	})
+	return b
+}
+
+func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVersionsResponse {
+	return kafkaapi.ApiVersionsResponse{
+		Version:        b.version,
+		ErrorCode:      b.errorCode,
+		ApiKeys:        b.apiKeys,
+		ThrottleTimeMs: b.throttleTimeMs,
+	}
+}

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -7,7 +7,7 @@ import (
 type ApiVersionsResponseBuilder struct {
 	version        int16
 	errorCode      int16
-	apiKeys        []kafkaapi.ApiKeyVersionSupport
+	apiKeys        []kafkaapi.ApiKeyEntry
 	throttleTimeMs int32
 }
 
@@ -16,7 +16,7 @@ func NewApiVersionsResponseBuilder() *ApiVersionsResponseBuilder {
 		version:        3,
 		errorCode:      0,
 		throttleTimeMs: 0,
-		apiKeys:        []kafkaapi.ApiKeyVersionSupport{},
+		apiKeys:        []kafkaapi.ApiKeyEntry{},
 	}
 }
 
@@ -30,8 +30,8 @@ func (b *ApiVersionsResponseBuilder) WithThrottleTimeMs(throttleTimeMs int32) *A
 	return b
 }
 
-func (b *ApiVersionsResponseBuilder) AddApiKeyVersionSupport(apiKey int16, minVersion int16, maxVersion int16) *ApiVersionsResponseBuilder {
-	b.apiKeys = append(b.apiKeys, kafkaapi.ApiKeyVersionSupport{
+func (b *ApiVersionsResponseBuilder) AddApiKeyEntry(apiKey int16, minVersion int16, maxVersion int16) *ApiVersionsResponseBuilder {
+	b.apiKeys = append(b.apiKeys, kafkaapi.ApiKeyEntry{
 		Version:    b.version,
 		ApiKey:     apiKey,
 		MinVersion: minVersion,

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -1,6 +1,8 @@
 package builder
 
-import kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+import (
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+)
 
 type ApiVersionsResponseBuilder struct {
 	version        int16
@@ -43,13 +45,17 @@ func (b *ApiVersionsResponseBuilder) AddApiKeyVersionSupport(apiKey int16, minVe
 	return b
 }
 
-// Build should return whole response
-// TODO: create separate ApiVersionsResponse and ApiVersionsResponseBody
 func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVersionsResponse {
 	return kafkaapi.ApiVersionsResponse{
-		Version:        b.version,
-		ErrorCode:      b.errorCode,
-		ApiKeys:        b.apiKeys,
-		ThrottleTimeMs: b.throttleTimeMs,
+		// TODO: Add ResponseHeaderBuilder
+		Header: kafkaapi.ResponseHeader{
+			CorrelationId: correlationId,
+		},
+		Body: kafkaapi.ApiVersionsResponseBody{
+			Version:        b.version,
+			ErrorCode:      b.errorCode,
+			ApiKeys:        b.apiKeys,
+			ThrottleTimeMs: 0,
+		},
 	}
 }

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,1 +1,0 @@
-package builder

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,5 +1,1 @@
 package builder
-
-// type ApiVersionsResponseBuilderI interface {
-// 	Build(correlationId int32) ApiVersionsResponseI
-// }

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,0 +1,5 @@
+package builder
+
+// type ApiVersionsResponseBuilderI interface {
+// 	Build(correlationId int32) ApiVersionsResponseI
+// }


### PR DESCRIPTION
### Description

- Rename `ApiVersionsResponseKey` to `ApiKeyVersionSupport` for clearer naming and consistency.
- Introduce `ApiVersionsResponseBuilder` to simplify and standardize API Versions response creation.
- Refactor code to use the builder pattern for constructing `ApiVersionsResponse` objects, enhancing readability and maintainability.
- Add a `Build` method to `ApiVersionsResponseBuilder` to encapsulate response creation and simplify client code.
- Include a placeholder interface `ApiVersionsResponseBuilderI` to define the builder contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a builder for constructing Kafka API Versions response messages, enabling more flexible and readable response creation.

* **Refactor**
  * Renamed several internal structures and fields for improved clarity and consistency in API version responses.
  * Updated error messages and context labels to reflect the new naming conventions.

* **Bug Fixes**
  * Adjusted tests and assertions to align with the new response structure and builder pattern.

* **Chores**
  * Updated internal tests and assertions to use the new builder and renamed types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->