### PR TITLE
Produce extension framework

### DIFF
--- a/internal/assertions/apiversions_response_assertion.go
+++ b/internal/assertions/apiversions_response_assertion.go
@@ -8,6 +8,7 @@ import (
 )
 
 var apiKeyNames = map[int16]string{
+	0:  "PRODUCE",
 	1:  "FETCH",
 	18: "API_VERSIONS",
 	75: "DESCRIBE_TOPIC_PARTITIONS",

--- a/internal/assertions/log_assertion.go
+++ b/internal/assertions/log_assertion.go
@@ -1,0 +1,91 @@
+package assertions
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/codecrafters-io/kafka-tester/internal/logparser"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type TopicPartitionLogAssertion struct {
+	topic         string
+	partition     int32
+	RecordBatches []kafkaapi.RecordBatch
+	logger        *logger.Logger
+}
+
+func NewTopicPartitionLogAssertion(topic string, partition int32, recordBatches []kafkaapi.RecordBatch, logger *logger.Logger) TopicPartitionLogAssertion {
+	return TopicPartitionLogAssertion{
+		topic:         topic,
+		partition:     partition,
+		RecordBatches: recordBatches,
+		logger:        logger,
+	}
+}
+
+func (a TopicPartitionLogAssertion) Run() error {
+	a.logger.UpdateLastSecondaryPrefix("logparser")
+	actualEncodedRecordBatches, err := encodeRecordBatchesInLogFile(a.topic, a.partition, a.logger)
+	a.logger.ResetSecondaryPrefixes()
+	if err != nil {
+		return err
+	}
+
+	expectedEncodedBatches := encodeMultipleRecordBatches(a.RecordBatches)
+
+	if len(actualEncodedRecordBatches) != len(expectedEncodedBatches) {
+		return fmt.Errorf("Expected %d RecordBatches in log file, got %d", len(expectedEncodedBatches), len(actualEncodedRecordBatches))
+	}
+
+	for i, actualEncodedRecordBatch := range actualEncodedRecordBatches {
+		expectedEncodedRecordBatch := expectedEncodedBatches[i]
+		if !bytes.Equal(actualEncodedRecordBatch, expectedEncodedRecordBatch) {
+			fmt.Println("actualEncodedRecordBatch", actualEncodedRecordBatch)
+			fmt.Println("expectedEncodedRecordBatch", expectedEncodedRecordBatch)
+			return fmt.Errorf("RecordBatches in log file do not match expected RecordBatches")
+		}
+	}
+
+	a.logger.Successf("✓ RecordBatches in log file match expected RecordBatches")
+
+	return nil
+}
+
+// getLogFilePathForTopic builds the log file path for a given topic and partition
+func getLogFilePathForTopic(topicName string, partition int32) string {
+	return fmt.Sprintf("%s/%s-%d/00000000000000000000.log", common.LOG_DIR, topicName, partition)
+}
+
+func encodeRecordBatchesInLogFile(topicName string, partition int32, logger *logger.Logger) ([][]byte, error) {
+	logFilePath := getLogFilePathForTopic(topicName, partition)
+
+	logParser := logparser.NewLogFileParser(logger)
+	result, err := logParser.ParseLogFile(logFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse log file %s: %w", logFilePath, err)
+	}
+
+	encodedBatches := make([][]byte, 0)
+
+	for _, batch := range result.RecordBatches {
+		as := serializer.GetEncodedBytes(batch)
+		encodedBatches = append(encodedBatches, as)
+	}
+
+	logger.Infof("Found %d RecordBatches in %s", len(result.RecordBatches), logFilePath)
+	return encodedBatches, nil
+}
+
+func encodeMultipleRecordBatches(recordBatches []kafkaapi.RecordBatch) [][]byte {
+	encodedBatches := make([][]byte, 0)
+	for i, recordBatch := range recordBatches {
+		recordBatch.BaseOffset = int64(i)
+		as := serializer.GetEncodedBytes(recordBatch)
+		encodedBatches = append(encodedBatches, as)
+	}
+	return encodedBatches
+}

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -79,12 +79,12 @@ func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 }
 
 func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
-	if len(a.ActualValue.Responses) != len(a.ExpectedValue.Responses) {
-		return fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.Responses), len(a.ActualValue.Responses))
+	if len(a.ActualValue.TopicResponses) != len(a.ExpectedValue.TopicResponses) {
+		return fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.TopicResponses), len(a.ActualValue.TopicResponses))
 	}
 
-	for i, actualTopic := range a.ActualValue.Responses {
-		expectedTopic := a.ExpectedValue.Responses[i]
+	for i, actualTopic := range a.ActualValue.TopicResponses {
+		expectedTopic := a.ExpectedValue.TopicResponses[i]
 
 		if !Contains(a.excludedTopicFields, "Name") {
 			if actualTopic.Name != expectedTopic.Name {
@@ -173,24 +173,24 @@ func (a *ProduceResponseAssertion) Run(logger *logger.Logger) error {
 // sortResponses sorts topics by name and partitions within each topic by index
 func sortResponses(response kafkaapi.ProduceResponseBody) kafkaapi.ProduceResponseBody {
 	sortedResponse := response
-	sortedResponse.Responses = make([]kafkaapi.ProduceTopicResponse, len(response.Responses))
-	copy(sortedResponse.Responses, response.Responses)
+	sortedResponse.TopicResponses = make([]kafkaapi.ProduceTopicResponse, len(response.TopicResponses))
+	copy(sortedResponse.TopicResponses, response.TopicResponses)
 
 	// Sort topics by name
-	sort.Slice(sortedResponse.Responses, func(i, j int) bool {
-		return sortedResponse.Responses[i].Name < sortedResponse.Responses[j].Name
+	sort.Slice(sortedResponse.TopicResponses, func(i, j int) bool {
+		return sortedResponse.TopicResponses[i].Name < sortedResponse.TopicResponses[j].Name
 	})
 
 	// Sort partitions within each topic by index
-	for i := range sortedResponse.Responses {
-		partitions := make([]kafkaapi.ProducePartitionResponse, len(sortedResponse.Responses[i].PartitionResponses))
-		copy(partitions, sortedResponse.Responses[i].PartitionResponses)
+	for i := range sortedResponse.TopicResponses {
+		partitions := make([]kafkaapi.ProducePartitionResponse, len(sortedResponse.TopicResponses[i].PartitionResponses))
+		copy(partitions, sortedResponse.TopicResponses[i].PartitionResponses)
 
 		sort.Slice(partitions, func(x, y int) bool {
 			return partitions[x].Index < partitions[y].Index
 		})
 
-		sortedResponse.Responses[i].PartitionResponses = partitions
+		sortedResponse.TopicResponses[i].PartitionResponses = partitions
 	}
 
 	return sortedResponse

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -166,11 +166,6 @@ func (a *ProduceResponseAssertion) Run(logger *logger.Logger) error {
 	if err := a.assertBody(logger); err != nil {
 		return err
 	}
-	if !Contains(a.excludedBodyFields, "topics") {
-		if err := a.assertTopics(logger); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -12,8 +12,14 @@ import (
 type ProduceResponseAssertion struct {
 	ActualValue   kafkaapi.ProduceResponseBody
 	ExpectedValue kafkaapi.ProduceResponseBody
-	logger        *logger.Logger
-	err           error
+
+	// empty slice = assert all fields (default)
+	// non-empty slice = assert with exclusions
+	// if excludedBodyFields contains "topics", then Topics are not asserted
+	// if excludedTopicFields contains "partitions", then Partitions are not asserted
+	excludedBodyFields      []string
+	excludedTopicFields     []string
+	excludedPartitionFields []string
 }
 
 func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponseBody, expectedValue kafkaapi.ProduceResponseBody, logger *logger.Logger) *ProduceResponseAssertion {
@@ -22,10 +28,37 @@ func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponseBody, expec
 	sortedExpected := sortResponses(expectedValue)
 
 	return &ProduceResponseAssertion{
-		ActualValue:   sortedActual,
-		ExpectedValue: sortedExpected,
-		logger:        logger,
+		ActualValue:             sortedActual,
+		ExpectedValue:           sortedExpected,
+		excludedBodyFields:      []string{},
+		excludedTopicFields:     []string{},
+		excludedPartitionFields: []string{},
 	}
+}
+
+func (a *ProduceResponseAssertion) ExcludeBodyFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedBodyFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) ExcludeTopicFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedTopicFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) ExcludePartitionFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedPartitionFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) SkipTopicFields() *ProduceResponseAssertion {
+	a.excludedBodyFields = append(a.excludedBodyFields, "topics")
+	return a
+}
+
+func (a *ProduceResponseAssertion) SkipPartitionFields() *ProduceResponseAssertion {
+	a.excludedTopicFields = append(a.excludedTopicFields, "partitions")
+	return a
 }
 
 func (a *ProduceResponseAssertion) AssertBody(fields []string) *ProduceResponseAssertion {

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -1,0 +1,174 @@
+package assertions
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/codecrafters-io/kafka-tester/protocol"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type ProduceResponseAssertion struct {
+	ActualValue   kafkaapi.ProduceResponseBody
+	ExpectedValue kafkaapi.ProduceResponseBody
+	logger        *logger.Logger
+	err           error
+}
+
+func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponseBody, expectedValue kafkaapi.ProduceResponseBody, logger *logger.Logger) *ProduceResponseAssertion {
+	// Sort both responses for consistent comparison
+	sortedActual := sortResponses(actualValue)
+	sortedExpected := sortResponses(expectedValue)
+
+	return &ProduceResponseAssertion{
+		ActualValue:   sortedActual,
+		ExpectedValue: sortedExpected,
+		logger:        logger,
+	}
+}
+
+func (a *ProduceResponseAssertion) AssertBody(fields []string) *ProduceResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	if Contains(fields, "ThrottleTimeMs") {
+		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
+			a.err = fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
+			return a
+		}
+		a.logger.Successf("✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
+	}
+
+	return a
+}
+
+func (a *ProduceResponseAssertion) AssertTopics(topicFields []string, partitionFields []string) *ProduceResponseAssertion {
+	if a.err != nil {
+		return a
+	}
+
+	if len(a.ActualValue.Responses) != len(a.ExpectedValue.Responses) {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.Responses), len(a.ActualValue.Responses))
+		return a
+	}
+
+	for i, actualTopic := range a.ActualValue.Responses {
+		expectedTopic := a.ExpectedValue.Responses[i]
+
+		if Contains(topicFields, "Name") {
+			if actualTopic.Name != expectedTopic.Name {
+				a.err = fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Name", i), expectedTopic.Name, actualTopic.Name)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 1, "✓ TopicResponse[%d] Name: %s", i, actualTopic.Name)
+		}
+
+		expectedPartitions := expectedTopic.PartitionResponses
+		actualPartitions := actualTopic.PartitionResponses
+
+		if (partitionFields) != nil {
+			a.assertPartitions(expectedPartitions, actualPartitions, partitionFields)
+		} else {
+			if len(actualPartitions) != 0 {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", 0, len(actualPartitions))
+				return a
+			}
+		}
+	}
+
+	return a
+}
+
+func (a *ProduceResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.ProducePartitionResponse, actualPartitions []kafkaapi.ProducePartitionResponse, fields []string) *ProduceResponseAssertion {
+	if len(actualPartitions) != len(expectedPartitions) {
+		a.err = fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
+		return a
+	}
+
+	for j, actualPartition := range actualPartitions {
+		expectedPartition := expectedPartitions[j]
+
+		if Contains(fields, "ErrorCode") {
+			if actualPartition.ErrorCode != expectedPartition.ErrorCode {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
+				return a
+			}
+
+			errorCodeName, ok := errorCodes[int(actualPartition.ErrorCode)]
+			if !ok {
+				errorCodeName = "UNKNOWN"
+			}
+
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Error code: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
+		}
+
+		if Contains(fields, "Index") {
+			if actualPartition.Index != expectedPartition.Index {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Index", j), expectedPartition.Index, actualPartition.Index)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] Index: %d", j, actualPartition.Index)
+		}
+
+		if Contains(fields, "BaseOffset") {
+			if actualPartition.BaseOffset != expectedPartition.BaseOffset {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] BaseOffset", j), expectedPartition.BaseOffset, actualPartition.BaseOffset)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] BaseOffset: %d", j, actualPartition.BaseOffset)
+		}
+
+		if Contains(fields, "LogStartOffset") {
+			if actualPartition.LogStartOffset != expectedPartition.LogStartOffset {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogStartOffset", j), expectedPartition.LogStartOffset, actualPartition.LogStartOffset)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] LogStartOffset: %d", j, actualPartition.LogStartOffset)
+		}
+
+		if Contains(fields, "LogAppendTimeMs") {
+			if actualPartition.LogAppendTimeMs != expectedPartition.LogAppendTimeMs {
+				a.err = fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogAppendTimeMs", j), expectedPartition.LogAppendTimeMs, actualPartition.LogAppendTimeMs)
+				return a
+			}
+			protocol.SuccessLogWithIndentation(a.logger, 2, "✓ PartitionResponse[%d] LogAppendTimeMs: %d", j, actualPartition.LogAppendTimeMs)
+		}
+	}
+
+	return a
+}
+
+func (a ProduceResponseAssertion) Run() error {
+	// firstLevelFields: ["ThrottleTimeMs"]
+	// secondLevelFields (Topics): ["Name"]
+	// thirdLevelFields (Partitions): ["ErrorCode", "Index", "BaseOffset", "LogStartOffset", "LogAppendTimeMs"]
+	return a.err
+}
+
+// sortResponses sorts topics by name and partitions within each topic by index
+func sortResponses(response kafkaapi.ProduceResponseBody) kafkaapi.ProduceResponseBody {
+	sortedResponse := response
+	sortedResponse.Responses = make([]kafkaapi.ProduceTopicResponse, len(response.Responses))
+	copy(sortedResponse.Responses, response.Responses)
+
+	// Sort topics by name
+	sort.Slice(sortedResponse.Responses, func(i, j int) bool {
+		return sortedResponse.Responses[i].Name < sortedResponse.Responses[j].Name
+	})
+
+	// Sort partitions within each topic by index
+	for i := range sortedResponse.Responses {
+		partitions := make([]kafkaapi.ProducePartitionResponse, len(sortedResponse.Responses[i].PartitionResponses))
+		copy(partitions, sortedResponse.Responses[i].PartitionResponses)
+
+		sort.Slice(partitions, func(x, y int) bool {
+			return partitions[x].Index < partitions[y].Index
+		})
+
+		sortedResponse.Responses[i].PartitionResponses = partitions
+	}
+
+	return sortedResponse
+}

--- a/internal/logparser/log_parser.go
+++ b/internal/logparser/log_parser.go
@@ -1,0 +1,87 @@
+package logparser
+
+import (
+	"fmt"
+	"os"
+
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type LogFileParser struct {
+	logger *logger.Logger
+}
+
+// LogFileResult contains the parsed data from a log file
+type LogFileResult struct {
+	FilePath      string
+	RecordBatches []kafkaapi.RecordBatch
+	Messages      []string
+	TotalRecords  int
+}
+
+func NewLogFileParser(logger *logger.Logger) *LogFileParser {
+	return &LogFileParser{
+		logger: logger,
+	}
+}
+
+func (p *LogFileParser) ParseLogFile(filePath string) (*LogFileResult, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s: %w", filePath, err)
+	}
+
+	if len(data) == 0 {
+		p.logger.Debugf("File %s is empty", filePath)
+		return &LogFileResult{
+			FilePath:      filePath,
+			RecordBatches: []kafkaapi.RecordBatch{},
+			Messages:      []string{},
+			TotalRecords:  0,
+		}, nil
+	}
+
+	return p.parseLogData(filePath, data)
+}
+
+func (p *LogFileParser) parseLogData(filePath string, data []byte) (*LogFileResult, error) {
+	realDecoder := &decoder.Decoder{}
+	realDecoder.Init(data)
+
+	result := &LogFileResult{
+		FilePath:      filePath,
+		RecordBatches: []kafkaapi.RecordBatch{},
+		Messages:      []string{},
+		TotalRecords:  0,
+	}
+
+	batchIndex := 0
+	for realDecoder.Remaining() > 0 {
+		recordBatch := kafkaapi.RecordBatch{}
+
+		p.logger.Debugf("Decoding RecordBatch[%d] at offset %d", batchIndex, realDecoder.Offset())
+
+		err := recordBatch.Decode(realDecoder, p.logger, 1)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding record batch %d: %w", batchIndex, err)
+		}
+
+		result.RecordBatches = append(result.RecordBatches, recordBatch)
+
+		for _, record := range recordBatch.Records {
+			if record.Value != nil {
+				result.Messages = append(result.Messages, string(record.Value))
+			}
+			result.TotalRecords++
+		}
+
+		batchIndex++
+	}
+
+	p.logger.Debugf("Successfully decoded %d record batches with %d total records",
+		len(result.RecordBatches), result.TotalRecords)
+
+	return result, nil
+}

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -46,3 +46,18 @@ func (r ApiVersionsRequest) GetHeader() headers.RequestHeader {
 func (r ApiVersionsRequest) Encode() []byte {
 	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
 }
+
+func (r ApiVersionsRequest) Encode() []byte {
+	encoder := encoder.Encoder{}
+	encoder.Init(make([]byte, 4096))
+
+	r.Header.Encode(&encoder)
+	r.Body.Encode(&encoder)
+	messageBytes := encoder.PackMessage()
+
+	return messageBytes
+}
+
+func (r ApiVersionsRequest) GetHeader() RequestHeader {
+	return r.Header
+}

--- a/protocol/api/produce.go
+++ b/protocol/api/produce.go
@@ -1,0 +1,69 @@
+package kafkaapi
+
+import (
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+
+	"github.com/codecrafters-io/kafka-tester/protocol/errors"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+func EncodeProduceRequest(request *ProduceRequest) []byte {
+	encoder := encoder.Encoder{}
+	// bytes.Buffer{}
+	encoder.Init(make([]byte, 4096))
+
+	request.Header.EncodeV2(&encoder)
+	request.Body.Encode(&encoder)
+	message := encoder.PackMessage()
+
+	return message
+}
+
+func DecodeProduceHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
+	decoder := decoder.Decoder{}
+	decoder.Init(response)
+	logger.UpdateLastSecondaryPrefix("Decoder")
+	defer logger.ResetSecondaryPrefixes()
+
+	responseHeader := ResponseHeader{}
+	logger.Debugf("- .ResponseHeader")
+	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
+		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
+			detailedError := decodingErr.WithAddedContext("Response Header").WithAddedContext("Produce Response v11")
+			return nil, decoder.FormatDetailedError(detailedError.Error())
+		}
+		return nil, err
+	}
+
+	return &responseHeader, nil
+}
+
+func DecodeProduceHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ProduceResponseBody, error) {
+	decoder := decoder.Decoder{}
+	decoder.Init(response)
+	logger.UpdateLastSecondaryPrefix("Decoder")
+	defer logger.ResetSecondaryPrefixes()
+
+	responseHeader := ResponseHeader{}
+	logger.Debugf("- .ResponseHeader")
+	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
+		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
+			detailedError := decodingErr.WithAddedContext("Response Header").WithAddedContext("Produce Response v11")
+			return nil, nil, decoder.FormatDetailedError(detailedError.Error())
+		}
+		return nil, nil, err
+	}
+
+	produceResponse := ProduceResponseBody{Version: version}
+	logger.Debugf("- .ResponseBody")
+	if err := produceResponse.Decode(&decoder, version, logger, 1); err != nil {
+		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
+			detailedError := decodingErr.WithAddedContext("Response Body").WithAddedContext("Produce Response v11")
+			return nil, nil, decoder.FormatDetailedError(detailedError.Error())
+		}
+		return nil, nil, err
+	}
+
+	return &responseHeader, &produceResponse, nil
+}

--- a/protocol/api/produce.go
+++ b/protocol/api/produce.go
@@ -2,42 +2,13 @@ package kafkaapi
 
 import (
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-func EncodeProduceRequest(request *ProduceRequest) []byte {
-	encoder := encoder.Encoder{}
-	// bytes.Buffer{}
-	encoder.Init(make([]byte, 4096))
-
-	request.Header.EncodeV2(&encoder)
-	request.Body.Encode(&encoder)
-	message := encoder.PackMessage()
-
-	return message
-}
-
-func DecodeProduceHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
-	decoder := decoder.Decoder{}
-	decoder.Init(response)
-	logger.UpdateLastSecondaryPrefix("Decoder")
-	defer logger.ResetSecondaryPrefixes()
-
-	responseHeader := ResponseHeader{}
-	logger.Debugf("- .ResponseHeader")
-	if err := responseHeader.DecodeV1(&decoder, logger, 1); err != nil {
-		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-			detailedError := decodingErr.WithAddedContext("Response Header").WithAddedContext("Produce Response v11")
-			return nil, decoder.FormatDetailedError(detailedError.Error())
-		}
-		return nil, err
-	}
-
-	return &responseHeader, nil
-}
+// TODO: Use an universal DecodeHeaderAndResponse function
+// Accept an API name, and based on it switch the decoder
 
 func DecodeProduceHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, *ProduceResponseBody, error) {
 	decoder := decoder.Decoder{}

--- a/protocol/builder/partition_response_builder.go
+++ b/protocol/builder/partition_response_builder.go
@@ -1,0 +1,72 @@
+package builder
+
+import (
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+)
+
+type PartitionResponseBuilder struct {
+	errorCode       int16
+	baseOffset      int64
+	logAppendTimeMs int64
+	logStartOffset  int64
+	recordErrors    []kafkaapi.RecordError
+	errorMessage    *string
+}
+
+func NewPartitionResponseBuilder() *PartitionResponseBuilder {
+	return &PartitionResponseBuilder{
+		errorCode:       0,
+		baseOffset:      0,
+		logAppendTimeMs: -1,
+		logStartOffset:  0,
+		recordErrors:    []kafkaapi.RecordError{},
+		errorMessage:    nil,
+	}
+}
+
+func (b *PartitionResponseBuilder) WithError(errorCode int16) *PartitionResponseBuilder {
+	b.errorCode = errorCode
+	if errorCode != 0 {
+		// When there's an error, set offsets to -1 (this matches the fixtures)
+		b.baseOffset = -1
+		b.logStartOffset = -1
+	}
+	return b
+}
+
+func (b *PartitionResponseBuilder) WithBaseOffset(baseOffset int64) *PartitionResponseBuilder {
+	b.baseOffset = baseOffset
+	return b
+}
+
+func (b *PartitionResponseBuilder) WithLogAppendTimeMs(logAppendTimeMs int64) *PartitionResponseBuilder {
+	b.logAppendTimeMs = logAppendTimeMs
+	return b
+}
+
+func (b *PartitionResponseBuilder) WithLogStartOffset(logStartOffset int64) *PartitionResponseBuilder {
+	b.logStartOffset = logStartOffset
+	return b
+}
+
+func (b *PartitionResponseBuilder) WithRecordErrors(recordErrors []kafkaapi.RecordError) *PartitionResponseBuilder {
+	b.recordErrors = recordErrors
+	return b
+}
+
+func (b *PartitionResponseBuilder) WithErrorMessage(errorMessage string) *PartitionResponseBuilder {
+	b.errorMessage = &errorMessage
+	return b
+}
+
+func (b *PartitionResponseBuilder) Build(partitionIndex int32) kafkaapi.ProducePartitionResponse {
+	return kafkaapi.ProducePartitionResponse{
+		Index:           partitionIndex,
+		ErrorCode:       b.errorCode,
+		BaseOffset:      b.baseOffset,
+		LogAppendTimeMs: b.logAppendTimeMs,
+		LogStartOffset:  b.logStartOffset,
+		RecordErrors:    b.recordErrors,
+		ErrorMessage:    b.errorMessage,
+	}
+}

--- a/protocol/builder/response_header_builder.go
+++ b/protocol/builder/response_header_builder.go
@@ -1,0 +1,28 @@
+package builder
+
+import (
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+)
+
+type ResponseHeaderBuilder struct {
+	correlationId int32
+}
+
+func NewResponseHeaderBuilder() *ResponseHeaderBuilder {
+	return &ResponseHeaderBuilder{}
+}
+
+func (rb *ResponseHeaderBuilder) WithCorrelationId(correlationId int32) *ResponseHeaderBuilder {
+	rb.correlationId = correlationId
+	return rb
+}
+
+func (rb *ResponseHeaderBuilder) Build() kafkaapi.ResponseHeader {
+	if rb.correlationId == 0 {
+		panic("CodeCrafters Internal Error: correlationId can't be 0 for building a response header")
+	}
+
+	return kafkaapi.ResponseHeader{
+		CorrelationId: rb.correlationId,
+	}
+}

--- a/protocol/serializer/utils.go
+++ b/protocol/serializer/utils.go
@@ -18,6 +18,12 @@ func GetEncodedBytes(encodableObject interface{}) []byte {
 	switch obj := encodableObject.(type) {
 	case kafkaapi.ClusterMetadataPayload:
 		obj.Encode(&encoder)
+	case kafkaapi.RecordBatch:
+		obj.Encode(&encoder)
+	case kafkaapi.Record:
+		obj.Encode(&encoder)
+	default:
+		panic(fmt.Sprintf("GetEncodedBytes: unsupported type: %T", obj))
 	}
 
 	encoded := encoder.Bytes()[:encoder.Offset()]


### PR DESCRIPTION
- Add ApiVersionsRequestBuilder for API version requests  
- Add Encode and GetHeader methods to ApiVersionsRequest for serialization and header access  
- Introduce ProduceResponseAssertion for detailed response validation  
- Add field exclusion options to ProduceResponseAssertion for selective assertion of response fields  
- Simplify ProduceResponseAssertion error handling and logging with immediate error returns and exclusion field checks  
- Fix missing API key PRODUCE in apiKeyNames map  
- Remove redundant topics assertion check

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #67 
- <kbd>&nbsp;2&nbsp;</kbd> #68 
- <kbd>&nbsp;1&nbsp;</kbd> #69 👈 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced detailed assertion tools for verifying Kafka Produce responses and log file contents, enabling more robust validation and error reporting.
  * Added utilities for decoding Kafka produce API responses and parsing Kafka log files.
  * Implemented builder patterns for constructing response headers and partition responses, supporting flexible and chainable configuration.

* **Improvements**
  * Enhanced encoding utilities to support additional Kafka record types.
  * Updated request encoding logic for more efficient processing and added simplified header retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->