### PR TITLE
Refactor signature of `SendAndReceive`

### DIFF
--- a/internal/fetch_test.go
+++ b/internal/fetch_test.go
@@ -23,7 +23,7 @@ func TestFetchv16With0Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := headers.ResponseHeader{Version: 1}
+	header := headers.ResponseHeader{}
 
 	if err = header.Decode(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -67,7 +67,7 @@ func TestFetchv16With1Message(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := headers.ResponseHeader{Version: 1}
+	header := headers.ResponseHeader{}
 
 	if err = header.Decode(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -120,7 +120,7 @@ func TestFetchv16With2Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := headers.ResponseHeader{Version: 1}
+	header := headers.ResponseHeader{}
 
 	if err = header.Decode(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -170,7 +170,7 @@ func TestFetchv16With3Messages(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	header := headers.ResponseHeader{Version: 1}
+	header := headers.ResponseHeader{}
 
 	if err = header.Decode(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
@@ -219,8 +219,8 @@ func TestAPIVersionv3(t *testing.T) {
 	decoder := decoder.Decoder{}
 	decoder.Init(b)
 
-	responseHeader := headers.ResponseHeader{Version: 0}
-	if err := responseHeader.Decode(&decoder, logger.GetQuietLogger(""), 0); err != nil {
+	responseHeader := headers.ResponseHeader{}
+	if err := responseHeader.DecodeV0(&decoder, logger.GetQuietLogger(""), 0); err != nil {
 		fmt.Println(decoder.FormatDetailedError(err.Error()))
 		return
 	}

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -10,7 +10,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -47,15 +46,11 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			},
 		}
 
-		message := request.Encode()
-		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-		response, err := client.SendAndReceive(message)
+		stageLogger.Infof("Sending request %d of %d:", i+1, requestCount)
+		response, err := client.SendAndReceive(&request, stageLogger)
 		if err != nil {
 			return err
 		}
-		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -4,12 +4,10 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -48,24 +46,17 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -4,12 +4,10 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -47,24 +45,17 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -56,9 +55,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -47,15 +46,10 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -55,15 +54,10 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -64,9 +63,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
@@ -58,9 +57,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -49,15 +48,10 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -66,15 +65,10 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -75,9 +74,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -73,9 +72,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -73,9 +72,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -4,7 +4,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/internal/assertions"
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
@@ -73,9 +72,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		return err
 	}
 
-	expectedResponseHeader := headers.ResponseHeader{
-		CorrelationId: correlationId,
-	}
+	expectedResponseHeader := builder.NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build()
 	if err = assertions.NewResponseHeaderAssertion(*responseHeader, expectedResponseHeader).Evaluate([]string{"CorrelationId"}, stageLogger); err != nil {
 		return err
 	}

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(&request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/test_helpers/fixtures/concurrent_stages/pass
+++ b/internal/test_helpers/fixtures/concurrent_stages/pass
@@ -4,7 +4,8 @@ Debug = true
 [33m[tester::#NH4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[tester::#NH4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[tester::#NH4] [0m[36mConnection to broker at localhost:9092 successful[0m
-[33m[tester::#NH4] [0m[94mSending request 1 of 2: "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
+[33m[tester::#NH4] [0m[94mSending request 1 of 2:[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m
@@ -367,7 +368,8 @@ Debug = true
 [33m[tester::#NH4] [0m[92m✓ API keys array is non-empty[0m
 [33m[tester::#NH4] [0m[92m✓ API version 4 is supported for API_VERSIONS[0m
 [33m[tester::#NH4] [0m[92m✓ Test 1 of 2: Passed[0m
-[33m[tester::#NH4] [0m[94mSending request 2 of 2: "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
+[33m[tester::#NH4] [0m[94mSending request 2 of 2:[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m

--- a/protocol/api/api_versions.go
+++ b/protocol/api/api_versions.go
@@ -3,10 +3,41 @@ package kafkaapi
 import (
 	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
+
+func EncodeApiVersionsRequest(request *ApiVersionsRequest) []byte {
+	encoder := encoder.Encoder{}
+	encoder.Init(make([]byte, 4096))
+
+	request.Header.Encode(&encoder)
+	request.Body.Encode(&encoder)
+	messageBytes := encoder.PackMessage()
+
+	return messageBytes
+}
+
+func DecodeApiVersionsHeader(response []byte, version int16, logger *logger.Logger) (*ResponseHeader, error) {
+	decoder := decoder.Decoder{}
+	decoder.Init(response)
+	logger.UpdateLastSecondaryPrefix("Decoder")
+	defer logger.ResetSecondaryPrefixes()
+
+	responseHeader := ResponseHeader{}
+	logger.Debugf("- .ResponseHeader")
+	// APIVersions always uses Header v0
+	if err := responseHeader.DecodeV0(&decoder, logger, 1); err != nil {
+		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
+			return nil, decodingErr.WithAddedContext("Response Header").WithAddedContext("ApiVersions v3")
+		}
+		return nil, err
+	}
+
+	return &responseHeader, nil
+}
 
 // DecodeApiVersionsHeaderAndResponse decodes the header and response
 // If an error is encountered while decoding, the returned objects are nil

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -3,6 +3,7 @@ package kafkaapi
 import (
 	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	kafka_interface "github.com/codecrafters-io/kafka-tester/protocol/interface"
 )
 
 type ApiVersionsRequestBody struct {
@@ -40,5 +41,13 @@ type ApiVersionsRequest struct {
 }
 
 func (r ApiVersionsRequest) Encode() []byte {
-	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
+	return encodeRequest(r)
+}
+
+func (r ApiVersionsRequest) GetHeader() headers.RequestHeader {
+	return r.Header
+}
+
+func (r ApiVersionsRequest) GetBody() kafka_interface.RequestBodyI {
+	return &r.Body
 }

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -49,5 +49,5 @@ func (r ApiVersionsRequest) GetHeader() headers.RequestHeader {
 }
 
 func (r ApiVersionsRequest) GetBody() kafka_interface.RequestBodyI {
-	return &r.Body
+	return r.Body
 }

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -1,9 +1,7 @@
 package kafkaapi
 
 import (
-	"fmt"
-
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
@@ -16,9 +14,11 @@ type ApiVersionsRequestBody struct {
 	ClientSoftwareVersion string
 }
 
-func (r ApiVersionsRequestBody) encode(enc *encoder.Encoder) {
-	if r.Version < 3 {
-		panic(fmt.Sprintf("CodeCrafters Internal Error: Unsupported API version: %d", r.Version))
+func (r ApiVersionsRequestBody) Encode(enc *encoder.Encoder) {
+	if r.Version >= 3 {
+		enc.PutCompactString(r.ClientSoftwareName)
+		enc.PutCompactString(r.ClientSoftwareVersion)
+		enc.PutEmptyTaggedFieldArray()
 	}
 	enc.PutCompactString(r.ClientSoftwareName)
 	enc.PutCompactString(r.ClientSoftwareVersion)

--- a/protocol/api/api_versions_response.go
+++ b/protocol/api/api_versions_response.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/codecrafters-io/kafka-tester/protocol"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"

--- a/protocol/api/describe_topic_partitions.go
+++ b/protocol/api/describe_topic_partitions.go
@@ -1,7 +1,7 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
@@ -15,7 +15,7 @@ func DecodeDescribeTopicPartitionsHeaderAndResponse(response []byte, logger *log
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := headers.ResponseHeader{Version: 1}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.Decode(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -1,18 +1,10 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	kafka_interface "github.com/codecrafters-io/kafka-tester/protocol/interface"
 )
-
-type DescribeTopicPartitionsRequest struct {
-	Header headers.RequestHeader
-	Body   DescribeTopicPartitionsRequestBody
-}
-
-func (r DescribeTopicPartitionsRequest) Encode() []byte {
-	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
-}
 
 type DescribeTopicPartitionsRequestBody struct {
 	Topics                 []TopicName
@@ -69,4 +61,21 @@ func (c *Cursor) Encode(pe *encoder.Encoder) {
 	pe.PutCompactString(c.TopicName)
 	pe.PutInt32(c.PartitionIndex)
 	pe.PutEmptyTaggedFieldArray()
+}
+
+type DescribeTopicPartitionsRequest struct {
+	Header headers.RequestHeader
+	Body   DescribeTopicPartitionsRequestBody
+}
+
+func (r DescribeTopicPartitionsRequest) Encode() []byte {
+	return encodeRequest(r)
+}
+
+func (r DescribeTopicPartitionsRequest) GetHeader() headers.RequestHeader {
+	return r.Header
+}
+
+func (r DescribeTopicPartitionsRequest) GetBody() kafka_interface.RequestBodyI {
+	return &r.Body
 }

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -12,7 +12,7 @@ type DescribeTopicPartitionsRequestBody struct {
 	Cursor                 Cursor
 }
 
-func (r DescribeTopicPartitionsRequestBody) encode(pe *encoder.Encoder) {
+func (r DescribeTopicPartitionsRequestBody) Encode(pe *encoder.Encoder) {
 	// Encode topics array length
 	pe.PutCompactArrayLength(len(r.Topics))
 
@@ -47,7 +47,7 @@ type TopicName struct {
 	Name string
 }
 
-func (t *TopicName) Encode(pe *encoder.Encoder) {
+func (t TopicName) Encode(pe *encoder.Encoder) {
 	pe.PutCompactString(t.Name)
 	pe.PutEmptyTaggedFieldArray()
 }
@@ -57,7 +57,7 @@ type Cursor struct {
 	PartitionIndex int32
 }
 
-func (c *Cursor) Encode(pe *encoder.Encoder) {
+func (c Cursor) Encode(pe *encoder.Encoder) {
 	pe.PutCompactString(c.TopicName)
 	pe.PutInt32(c.PartitionIndex)
 	pe.PutEmptyTaggedFieldArray()
@@ -77,5 +77,5 @@ func (r DescribeTopicPartitionsRequest) GetHeader() headers.RequestHeader {
 }
 
 func (r DescribeTopicPartitionsRequest) GetBody() kafka_interface.RequestBodyI {
-	return &r.Body
+	return r.Body
 }

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -1,9 +1,8 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
-
 	"github.com/codecrafters-io/kafka-tester/protocol/errors"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
@@ -14,7 +13,7 @@ func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := headers.ResponseHeader{Version: 1}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.Decode(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
@@ -33,7 +32,7 @@ func DecodeFetchHeaderAndResponse(response []byte, version int16, logger *logger
 	logger.UpdateLastSecondaryPrefix("Decoder")
 	defer logger.ResetSecondaryPrefixes()
 
-	responseHeader := headers.ResponseHeader{Version: 1}
+	responseHeader := headers.ResponseHeader{}
 	logger.Debugf("- .ResponseHeader")
 	if err := responseHeader.Decode(&decoder, logger, 1); err != nil {
 		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -1,8 +1,9 @@
 package kafkaapi
 
 import (
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	kafka_interface "github.com/codecrafters-io/kafka-tester/protocol/interface"
 )
 
 type Partition struct {
@@ -62,15 +63,6 @@ func (f *ForgottenTopic) Encode(pe *encoder.Encoder) {
 	pe.PutCompactInt32Array(f.Partitions)
 }
 
-type FetchRequest struct {
-	Header headers.RequestHeader
-	Body   FetchRequestBody
-}
-
-func (r FetchRequest) Encode() []byte {
-	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
-}
-
 type FetchRequestBody struct {
 	MaxWaitMS         int32
 	MinBytes          int32
@@ -112,11 +104,19 @@ func (r FetchRequestBody) encode(pe *encoder.Encoder) {
 	pe.PutEmptyTaggedFieldArray()
 }
 
-func (r FetchRequestBody) Encode() []byte {
-	encoder := encoder.Encoder{}
-	encoder.Init(make([]byte, 4096))
+type FetchRequest struct {
+	Header headers.RequestHeader
+	Body   FetchRequestBody
+}
 
-	r.encode(&encoder)
+func (r *FetchRequest) Encode() []byte {
+	return encodeRequest(r)
+}
 
-	return encoder.ToBytes()
+func (r *FetchRequest) GetHeader() headers.RequestHeader {
+	return r.Header
+}
+
+func (r *FetchRequest) GetBody() kafka_interface.RequestBodyI {
+	return &r.Body
 }

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -15,7 +15,7 @@ type Partition struct {
 	PartitionMaxBytes  int32 // max bytes to fetch
 }
 
-func (p *Partition) Encode(pe *encoder.Encoder) {
+func (p Partition) Encode(pe *encoder.Encoder) {
 	pe.PutInt32(p.ID)
 	pe.PutInt32(p.CurrentLeaderEpoch)
 	pe.PutInt64(p.FetchOffset)
@@ -30,7 +30,7 @@ type Topic struct {
 	Partitions []Partition
 }
 
-func (t *Topic) Encode(pe *encoder.Encoder) {
+func (t Topic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(t.TopicUUID)
 	if err != nil {
 		return
@@ -53,7 +53,7 @@ type ForgottenTopic struct {
 	Partitions []int32
 }
 
-func (f *ForgottenTopic) Encode(pe *encoder.Encoder) {
+func (f ForgottenTopic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(f.TopicUUID)
 	if err != nil {
 		return
@@ -75,7 +75,7 @@ type FetchRequestBody struct {
 	RackID            string
 }
 
-func (r FetchRequestBody) encode(pe *encoder.Encoder) {
+func (r FetchRequestBody) Encode(pe *encoder.Encoder) {
 	pe.PutInt32(r.MaxWaitMS)
 	pe.PutInt32(r.MinBytes)
 	pe.PutInt32(r.MaxBytes)
@@ -109,14 +109,14 @@ type FetchRequest struct {
 	Body   FetchRequestBody
 }
 
-func (r *FetchRequest) Encode() []byte {
+func (r FetchRequest) Encode() []byte {
 	return encodeRequest(r)
 }
 
-func (r *FetchRequest) GetHeader() headers.RequestHeader {
+func (r FetchRequest) GetHeader() headers.RequestHeader {
 	return r.Header
 }
 
-func (r *FetchRequest) GetBody() kafka_interface.RequestBodyI {
-	return &r.Body
+func (r FetchRequest) GetBody() kafka_interface.RequestBodyI {
+	return r.Body
 }

--- a/protocol/api/headers/request_header.go
+++ b/protocol/api/headers/request_header.go
@@ -1,4 +1,4 @@
-package headers
+package kafkaapi
 
 import (
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
@@ -16,20 +16,11 @@ type RequestHeader struct {
 	ClientId string
 }
 
-// encode v2
-func (h RequestHeader) encode(enc *encoder.Encoder) {
+// Encode v2
+func (h RequestHeader) Encode(enc *encoder.Encoder) {
 	enc.PutInt16(h.ApiKey)
 	enc.PutInt16(h.ApiVersion)
 	enc.PutInt32(h.CorrelationId)
 	enc.PutString(h.ClientId)
 	enc.PutEmptyTaggedFieldArray()
-}
-
-func (h RequestHeader) Encode() []byte {
-	encoder := encoder.Encoder{}
-	encoder.Init(make([]byte, 4096))
-
-	h.encode(&encoder)
-
-	return encoder.ToBytes()
 }

--- a/protocol/api/request.go
+++ b/protocol/api/request.go
@@ -1,0 +1,16 @@
+package kafkaapi
+
+import (
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+	kafka_interface "github.com/codecrafters-io/kafka-tester/protocol/interface"
+)
+
+func encodeRequest(req kafka_interface.RequestI) []byte {
+	encoder := encoder.Encoder{}
+	encoder.Init(make([]byte, 4096))
+
+	req.GetHeader().Encode(&encoder)
+	req.GetBody().Encode(&encoder)
+
+	return encoder.PackMessage()
+}

--- a/protocol/builder/api_versions_response_builder.go
+++ b/protocol/builder/api_versions_response_builder.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
-	"github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 )
 
 type ApiVersionsResponseBuilder struct {
@@ -43,10 +42,7 @@ func (b *ApiVersionsResponseBuilder) AddApiKeyEntry(apiKey int16, minVersion int
 
 func (b *ApiVersionsResponseBuilder) Build(correlationId int32) kafkaapi.ApiVersionsResponse {
 	return kafkaapi.ApiVersionsResponse{
-		// TODO: Add ResponseHeaderBuilder
-		Header: headers.ResponseHeader{
-			CorrelationId: correlationId,
-		},
+		Header: NewResponseHeaderBuilder().WithCorrelationId(correlationId).Build(),
 		Body: kafkaapi.ApiVersionsResponseBody{
 			Version:        b.version,
 			ErrorCode:      b.errorCode,

--- a/protocol/builder/request_header_builder.go
+++ b/protocol/builder/request_header_builder.go
@@ -1,6 +1,6 @@
 package builder
 
-import "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+import headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
 
 type RequestHeaderBuilder struct {
 	apiKey        int16

--- a/protocol/builder/response_header_builder.go
+++ b/protocol/builder/response_header_builder.go
@@ -20,7 +20,7 @@ func (rb *ResponseHeaderBuilder) WithCorrelationId(correlationId int32) *Respons
 }
 
 func (rb *ResponseHeaderBuilder) Build() headers.ResponseHeader {
-	if rb.correlationId == 0 {
+	if rb.correlationId == -1 {
 		panic("CodeCrafters Internal Error: correlationId can't be -1 for building a response header")
 	}
 

--- a/protocol/builder/response_header_builder.go
+++ b/protocol/builder/response_header_builder.go
@@ -1,0 +1,30 @@
+package builder
+
+import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+)
+
+type ResponseHeaderBuilder struct {
+	correlationId int32
+}
+
+func NewResponseHeaderBuilder() *ResponseHeaderBuilder {
+	return &ResponseHeaderBuilder{
+		correlationId: -1,
+	}
+}
+
+func (rb *ResponseHeaderBuilder) WithCorrelationId(correlationId int32) *ResponseHeaderBuilder {
+	rb.correlationId = correlationId
+	return rb
+}
+
+func (rb *ResponseHeaderBuilder) Build() headers.ResponseHeader {
+	if rb.correlationId == 0 {
+		panic("CodeCrafters Internal Error: correlationId can't be -1 for building a response header")
+	}
+
+	return headers.ResponseHeader{
+		CorrelationId: rb.correlationId,
+	}
+}

--- a/protocol/interface/interface.go
+++ b/protocol/interface/interface.go
@@ -1,0 +1,16 @@
+package kafka_interface
+
+import (
+	headers "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
+)
+
+type RequestI interface {
+	Encode() []byte
+	GetHeader() headers.RequestHeader
+	GetBody() RequestBodyI
+}
+
+type RequestBodyI interface {
+	Encode(pe *encoder.Encoder)
+}

--- a/protocol/utils/utils.go
+++ b/protocol/utils/utils.go
@@ -46,3 +46,20 @@ func GetFormattedHexdump(data []byte) string {
 
 	return formattedHexdump.String()
 }
+
+func APIKeyToName(apiKey int16) string {
+	switch apiKey {
+	case 0:
+		return "Produce"
+	case 1:
+		return "Fetch"
+	case 18:
+		return "ApiVersions"
+	case 19:
+		return "CreateTopics"
+	case 75:
+		return "DescribeTopicPartitions"
+	default:
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Unknown API key: %v", apiKey))
+	}
+}


### PR DESCRIPTION
### Description

- Simplified request sending and response header building in stages  
- Modified SendAndReceive to accept request and logger directly for simpler calls  
- Enhanced SendAndReceive to log detailed request and response information

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #71 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #70 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added builder utilities for constructing response headers with a fluent interface.
  * Introduced interfaces for Kafka request objects and bodies to standardize encoding and access patterns.
  * Added helper functions for encoding and decoding specific Kafka protocol messages.

* **Refactor**
  * Simplified request sending by delegating encoding and logging to a unified method, reducing manual encoding and hexdump logging.
  * Standardized encoding logic across various request types using centralized functions and interfaces.
  * Updated method receivers for encoding functions to use value receivers for consistency.

* **Bug Fixes**
  * Improved error handling and context in protocol message decoding.

* **Style**
  * Updated import statements for clarity and consistency.

* **Documentation**
  * Improved method comments and log message formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->