### PR TITLE
Update signature of `SendAndReceive`

### DIFF
--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -47,7 +47,7 @@ func testAPIVersion(stageHarness *test_case_harness.TestCaseHarness) error {
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -51,7 +51,7 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
 		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-		response, err := client.SendAndReceive(message)
+		response, err := client.SendAndReceive(request, stageLogger)
 		if err != nil {
 			return err
 		}

--- a/internal/stage_c1.go
+++ b/internal/stage_c1.go
@@ -10,7 +10,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -47,15 +46,10 @@ func testSequentialRequests(stageHarness *test_case_harness.TestCaseHarness) err
 			},
 		}
 
-		message := request.Encode()
-		stageLogger.Infof("Sending request %v of %v: \"ApiVersions\" (version: %v) request (Correlation id: %v)", i+1, requestCount, request.Header.ApiVersion, request.Header.CorrelationId)
-		stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 		response, err := client.SendAndReceive(request, stageLogger)
 		if err != nil {
 			return err
 		}
-		stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 		responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 		if err != nil {

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -47,7 +47,7 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp1.go
+++ b/internal/stage_dtp1.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersionWithDescribeTopicPartitions(stageHarness *test_case_harness.T
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -52,7 +52,7 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp2.go
+++ b/internal/stage_dtp2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -48,15 +47,10 @@ func testDTPartitionWithUnknownTopic(stageHarness *test_case_harness.TestCaseHar
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -51,7 +51,7 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp3.go
+++ b/internal/stage_dtp3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -47,15 +46,10 @@ func testDTPartitionWithTopicAndSinglePartition(stageHarness *test_case_harness.
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -47,15 +46,10 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_dtp4.go
+++ b/internal/stage_dtp4.go
@@ -51,7 +51,7 @@ func testDTPartitionWithTopicAndMultiplePartitions2(stageHarness *test_case_harn
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -59,7 +59,7 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_dtp5.go
+++ b/internal/stage_dtp5.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -55,15 +54,10 @@ func testDTPartitionWithTopics(stageHarness *test_case_harness.TestCaseHarness) 
 	// response for topicResponses will be sorted by topic name
 	// bar -> baz -> foo
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"DescribeTopicPartitions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"DescribeTopicPartitions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"DescribeTopicPartitions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeDescribeTopicPartitionsHeaderAndResponse(response.Payload, stageLogger)
 	if err != nil {

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -47,7 +47,7 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f1.go
+++ b/internal/stage_f1.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
@@ -43,15 +42,10 @@ func testAPIVersionWithFetchKey(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"ApiVersions\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeApiVersionsHeaderAndResponse(response.Payload, 3, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -8,7 +8,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/builder"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -49,15 +48,10 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f2.go
+++ b/internal/stage_f2.go
@@ -53,7 +53,7 @@ func testFetchWithNoTopics(stageHarness *test_case_harness.TestCaseHarness) erro
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -70,7 +70,7 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f3.go
+++ b/internal/stage_f3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -66,15 +65,10 @@ func testFetchWithUnknownTopicID(stageHarness *test_case_harness.TestCaseHarness
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -68,7 +68,7 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f4.go
+++ b/internal/stage_f4.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchNoMessages(stageHarness *test_case_harness.TestCaseHarness) error 
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -68,7 +68,7 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/stage_f5.go
+++ b/internal/stage_f5.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchWithSingleMessage(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -64,15 +63,10 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 		},
 	}
 
-	message := request.Encode()
-	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
-
 	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}
-	stageLogger.Debugf("Hexdump of received \"Fetch\" response: \n%v\n", utils.GetFormattedHexdump(response.RawBytes))
 
 	responseHeader, responseBody, err := kafkaapi.DecodeFetchHeaderAndResponse(response.Payload, 16, stageLogger)
 	if err != nil {

--- a/internal/stage_f6.go
+++ b/internal/stage_f6.go
@@ -68,7 +68,7 @@ func testFetchMultipleMessages(stageHarness *test_case_harness.TestCaseHarness) 
 	stageLogger.Infof("Sending \"Fetch\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
 	stageLogger.Debugf("Hexdump of sent \"Fetch\" request: \n%v\n", utils.GetFormattedHexdump(message))
 
-	response, err := client.SendAndReceive(message)
+	response, err := client.SendAndReceive(request, stageLogger)
 	if err != nil {
 		return err
 	}

--- a/internal/test_helpers/fixtures/concurrent_stages/pass
+++ b/internal/test_helpers/fixtures/concurrent_stages/pass
@@ -4,7 +4,7 @@ Debug = true
 [33m[tester::#NH4] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
 [33m[tester::#NH4] [0m[36mConnecting to broker at: localhost:9092[0m
 [33m[tester::#NH4] [0m[36mConnection to broker at localhost:9092 successful[0m
-[33m[tester::#NH4] [0m[94mSending request 1 of 2: "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 1616512461)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m
@@ -367,7 +367,7 @@ Debug = true
 [33m[tester::#NH4] [0m[92m✓ API keys array is non-empty[0m
 [33m[tester::#NH4] [0m[92m✓ API version 4 is supported for API_VERSIONS[0m
 [33m[tester::#NH4] [0m[92m✓ Test 1 of 2: Passed[0m
-[33m[tester::#NH4] [0m[94mSending request 2 of 2: "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
+[33m[tester::#NH4] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 96710698)[0m
 [33m[tester::#NH4] [0m[36mHexdump of sent "ApiVersions" request: [0m
 [33m[tester::#NH4] [0m[36mIdx  | Hex                                             | ASCII[0m
 [33m[tester::#NH4] [0m[36m-----+-------------------------------------------------+-----------------[0m

--- a/protocol/api/api_versions_request.go
+++ b/protocol/api/api_versions_request.go
@@ -39,6 +39,10 @@ type ApiVersionsRequest struct {
 	Body   ApiVersionsRequestBody
 }
 
+func (r ApiVersionsRequest) GetHeader() headers.RequestHeader {
+	return r.Header
+}
+
 func (r ApiVersionsRequest) Encode() []byte {
 	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
 }

--- a/protocol/api/describe_topic_partitions_request.go
+++ b/protocol/api/describe_topic_partitions_request.go
@@ -5,13 +5,24 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/encoder"
 )
 
-type DescribeTopicPartitionsRequest struct {
-	Header headers.RequestHeader
-	Body   DescribeTopicPartitionsRequestBody
+type TopicName struct {
+	Name string
 }
 
-func (r DescribeTopicPartitionsRequest) Encode() []byte {
-	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
+func (t TopicName) Encode(pe *encoder.Encoder) {
+	pe.PutCompactString(t.Name)
+	pe.PutEmptyTaggedFieldArray()
+}
+
+type Cursor struct {
+	TopicName      string
+	PartitionIndex int32
+}
+
+func (c Cursor) Encode(pe *encoder.Encoder) {
+	pe.PutCompactString(c.TopicName)
+	pe.PutInt32(c.PartitionIndex)
+	pe.PutEmptyTaggedFieldArray()
 }
 
 type DescribeTopicPartitionsRequestBody struct {
@@ -51,22 +62,15 @@ func (r DescribeTopicPartitionsRequestBody) Encode() []byte {
 	return encoder.ToBytes()
 }
 
-type TopicName struct {
-	Name string
+type DescribeTopicPartitionsRequest struct {
+	Header headers.RequestHeader
+	Body   DescribeTopicPartitionsRequestBody
 }
 
-func (t *TopicName) Encode(pe *encoder.Encoder) {
-	pe.PutCompactString(t.Name)
-	pe.PutEmptyTaggedFieldArray()
+func (r DescribeTopicPartitionsRequest) GetHeader() headers.RequestHeader {
+	return r.Header
 }
 
-type Cursor struct {
-	TopicName      string
-	PartitionIndex int32
-}
-
-func (c *Cursor) Encode(pe *encoder.Encoder) {
-	pe.PutCompactString(c.TopicName)
-	pe.PutInt32(c.PartitionIndex)
-	pe.PutEmptyTaggedFieldArray()
+func (r DescribeTopicPartitionsRequest) Encode() []byte {
+	return encoder.PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
 }

--- a/protocol/api/fetch.go
+++ b/protocol/api/fetch.go
@@ -8,25 +8,6 @@ import (
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
-func DecodeFetchHeader(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, error) {
-	decoder := decoder.Decoder{}
-	decoder.Init(response)
-	logger.UpdateLastSecondaryPrefix("Decoder")
-	defer logger.ResetSecondaryPrefixes()
-
-	responseHeader := headers.ResponseHeader{Version: 1}
-	logger.Debugf("- .ResponseHeader")
-	if err := responseHeader.Decode(&decoder, logger, 1); err != nil {
-		if decodingErr, ok := err.(*errors.PacketDecodingError); ok {
-			detailedError := decodingErr.WithAddedContext("Response Header").WithAddedContext("Fetch Response v16")
-			return nil, decoder.FormatDetailedError(detailedError.Error())
-		}
-		return nil, err
-	}
-
-	return &responseHeader, nil
-}
-
 func DecodeFetchHeaderAndResponse(response []byte, version int16, logger *logger.Logger) (*headers.ResponseHeader, *FetchResponse, error) {
 	decoder := decoder.Decoder{}
 	decoder.Init(response)

--- a/protocol/api/fetch_request.go
+++ b/protocol/api/fetch_request.go
@@ -14,7 +14,7 @@ type Partition struct {
 	PartitionMaxBytes  int32 // max bytes to fetch
 }
 
-func (p *Partition) Encode(pe *encoder.Encoder) {
+func (p Partition) Encode(pe *encoder.Encoder) {
 	pe.PutInt32(p.ID)
 	pe.PutInt32(p.CurrentLeaderEpoch)
 	pe.PutInt64(p.FetchOffset)
@@ -29,7 +29,7 @@ type Topic struct {
 	Partitions []Partition
 }
 
-func (t *Topic) Encode(pe *encoder.Encoder) {
+func (t Topic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(t.TopicUUID)
 	if err != nil {
 		return
@@ -52,7 +52,7 @@ type ForgottenTopic struct {
 	Partitions []int32
 }
 
-func (f *ForgottenTopic) Encode(pe *encoder.Encoder) {
+func (f ForgottenTopic) Encode(pe *encoder.Encoder) {
 	uuidBytes, err := encoder.EncodeUUID(f.TopicUUID)
 	if err != nil {
 		return
@@ -65,6 +65,10 @@ func (f *ForgottenTopic) Encode(pe *encoder.Encoder) {
 type FetchRequest struct {
 	Header headers.RequestHeader
 	Body   FetchRequestBody
+}
+
+func (r FetchRequest) GetHeader() headers.RequestHeader {
+	return r.Header
 }
 
 func (r FetchRequest) Encode() []byte {

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,6 +1,0 @@
-package kafka_interface
-
-type RequestI interface {
-	Encode() []byte
-	GetHeader() kafkaapi.RequestHeader
-}

--- a/protocol/builder/interface.go
+++ b/protocol/builder/interface.go
@@ -1,0 +1,6 @@
+package kafka_interface
+
+type RequestI interface {
+	Encode() []byte
+	GetHeader() kafkaapi.RequestHeader
+}

--- a/protocol/interface/interface.go
+++ b/protocol/interface/interface.go
@@ -1,0 +1,8 @@
+package kafka_interface
+
+import "github.com/codecrafters-io/kafka-tester/protocol/api/headers"
+
+type RequestI interface {
+	Encode() []byte
+	GetHeader() headers.RequestHeader
+}

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -86,13 +86,13 @@ func (c *Client) Close() error {
 
 func (c *Client) SendAndReceive(request kafka_interface.RequestI, stageLogger *logger.Logger) (Response, error) {
 	header := request.GetHeader()
-	apiType := utils.APIKeyToName(header.ApiKey)
+	apiName := utils.APIKeyToName(header.ApiKey)
 	apiVersion := header.ApiVersion
 	correlationId := header.CorrelationId
 	message := request.Encode()
 
-	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiType, apiVersion, correlationId)
-	stageLogger.Debugf("Hexdump of sent \"%s\" request: \n%v\n", apiType, utils.GetFormattedHexdump(message))
+	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiName, apiVersion, correlationId)
+	stageLogger.Debugf("Hexdump of sent \"%s\" request: \n%v\n", apiName, utils.GetFormattedHexdump(message))
 
 	response := Response{}
 
@@ -106,7 +106,7 @@ func (c *Client) SendAndReceive(request kafka_interface.RequestI, stageLogger *l
 		return response, err
 	}
 
-	stageLogger.Debugf("Hexdump of received \"%s\" response: \n%v\n", apiType, utils.GetFormattedHexdump(response.RawBytes))
+	stageLogger.Debugf("Hexdump of received \"%s\" response: \n%v\n", apiName, utils.GetFormattedHexdump(response.RawBytes))
 
 	return response, nil
 }

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
@@ -82,10 +83,19 @@ func (c *Client) Close() error {
 	return nil
 }
 
-func (c *Client) SendAndReceive(request []byte) (Response, error) {
+func (c *Client) SendAndReceive(request kafka_interface.RequestI, stageLogger *logger.Logger) (Response, error) {
+	header := request.GetHeader()
+	apiType := utils.APIKeyToName(header.ApiKey)
+	apiVersion := header.ApiVersion
+	correlationId := header.CorrelationId
+	message := request.Encode()
+
+	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiType, apiVersion, correlationId)
+	stageLogger.Debugf("Hexdump of sent \"%s\" request: \n%v\n", apiType, utils.GetFormattedHexdump(message))
+
 	response := Response{}
 
-	err := c.Send(request)
+	err := c.Send(message)
 	if err != nil {
 		return response, err
 	}
@@ -94,6 +104,8 @@ func (c *Client) SendAndReceive(request []byte) (Response, error) {
 	if err != nil {
 		return response, err
 	}
+
+	stageLogger.Debugf("Hexdump of received \"%s\" response: \n%v\n", apiType, utils.GetFormattedHexdump(response.RawBytes))
 
 	return response, nil
 }

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	kafka_interface "github.com/codecrafters-io/kafka-tester/protocol/interface"
 	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 )

--- a/protocol/utils/utils.go
+++ b/protocol/utils/utils.go
@@ -5,6 +5,23 @@ import (
 	"strings"
 )
 
+func APIKeyToName(apiKey int16) string {
+	switch apiKey {
+	case 0:
+		return "Produce"
+	case 1:
+		return "Fetch"
+	case 18:
+		return "ApiVersions"
+	case 19:
+		return "CreateTopics"
+	case 75:
+		return "DescribeTopicPartitions"
+	default:
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Unknown API key: %v", apiKey))
+	}
+}
+
 func GetFormattedHexdump(data []byte) string {
 	// This is used for logs
 	// Contains headers + vertical & horizontal separators + offset


### PR DESCRIPTION
- Added API key mapping and enhanced client request logging  
- Unified RequestI interface under kafka_interface package  
- Added GetHeader methods and improved encoding consistency  
- Added alias for kafka interface import in client.go  
- Updated SendAndReceive to accept request and logger for better logging  
- Removed unused DecodeFetchHeader function to simplify codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced logging for outgoing requests, including request type, version, and correlation ID.
  * Introduced a unified interface for encoding requests and accessing request headers.

* **Refactor**
  * Updated request handling to use structured request objects instead of raw byte slices.
  * Standardized encoding methods and request header access across multiple request types.
  * Improved code organization by separating and clarifying request and encoding logic.
  * Removed detailed hexdump logging of sent and received messages in favor of integrated logging within request handling.

* **Bug Fixes**
  * None.

* **Chores**
  * Removed unused decoding functions and updated method receivers for consistency.
  * Simplified test logs by removing redundant request count prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->