### PR TITLE
Add `Produce` assertions

### DIFF
--- a/internal/assertions/log_assertion.go
+++ b/internal/assertions/log_assertion.go
@@ -9,7 +9,6 @@ import (
 	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
 	"github.com/codecrafters-io/kafka-tester/protocol/common"
 	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
-	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
 	"github.com/codecrafters-io/tester-utils/logger"
 )
 
@@ -60,13 +59,6 @@ func (a TopicPartitionLogAssertion) Run(logger *logger.Logger) error {
 
 	if len(logParser.RecordBatches) != len(a.RecordBatches) {
 		return fmt.Errorf("Expected %d RecordBatches in log file (%s), got %d", len(a.RecordBatches), logFilePath, len(logParser.RecordBatches))
-	}
-
-	for i, actualRecordBatch := range logParser.RecordBatches {
-		expectedRecordBatch := a.RecordBatches[i]
-		if !bytes.Equal(serializer.GetEncodedBytes(actualRecordBatch), serializer.GetEncodedBytes(expectedRecordBatch)) {
-			return fmt.Errorf("RecordBatches in log file (%s) do not match expected RecordBatches", logFilePath)
-		}
 	}
 
 	return formattedError("mismatch here\n"+finalErr.Error(), mismatchOffset, logParser.RawBytes)

--- a/internal/assertions/log_assertion.go
+++ b/internal/assertions/log_assertion.go
@@ -1,0 +1,91 @@
+package assertions
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/codecrafters-io/kafka-tester/internal/logparser"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type TopicPartitionLogAssertion struct {
+	topic         string
+	partition     int32
+	RecordBatches []kafkaapi.RecordBatch
+	logger        *logger.Logger
+}
+
+func NewTopicPartitionLogAssertion(topic string, partition int32, recordBatches []kafkaapi.RecordBatch, logger *logger.Logger) TopicPartitionLogAssertion {
+	return TopicPartitionLogAssertion{
+		topic:         topic,
+		partition:     partition,
+		RecordBatches: recordBatches,
+		logger:        logger,
+	}
+}
+
+func (a TopicPartitionLogAssertion) Run() error {
+	a.logger.UpdateLastSecondaryPrefix("logparser")
+	actualEncodedRecordBatches, err := encodeRecordBatchesInLogFile(a.topic, a.partition, a.logger)
+	a.logger.ResetSecondaryPrefixes()
+	if err != nil {
+		return err
+	}
+
+	expectedEncodedBatches := encodeMultipleRecordBatches(a.RecordBatches)
+
+	if len(actualEncodedRecordBatches) != len(expectedEncodedBatches) {
+		return fmt.Errorf("Expected %d RecordBatches in log file, got %d", len(expectedEncodedBatches), len(actualEncodedRecordBatches))
+	}
+
+	for i, actualEncodedRecordBatch := range actualEncodedRecordBatches {
+		expectedEncodedRecordBatch := expectedEncodedBatches[i]
+		if !bytes.Equal(actualEncodedRecordBatch, expectedEncodedRecordBatch) {
+			fmt.Println("actualEncodedRecordBatch", actualEncodedRecordBatch)
+			fmt.Println("expectedEncodedRecordBatch", expectedEncodedRecordBatch)
+			return fmt.Errorf("RecordBatches in log file do not match expected RecordBatches")
+		}
+	}
+
+	a.logger.Successf("✓ RecordBatches in log file match expected RecordBatches")
+
+	return nil
+}
+
+// getLogFilePathForTopic builds the log file path for a given topic and partition
+func getLogFilePathForTopic(topicName string, partition int32) string {
+	return fmt.Sprintf("%s/%s-%d/00000000000000000000.log", common.LOG_DIR, topicName, partition)
+}
+
+func encodeRecordBatchesInLogFile(topicName string, partition int32, logger *logger.Logger) ([][]byte, error) {
+	logFilePath := getLogFilePathForTopic(topicName, partition)
+
+	logParser := logparser.NewLogFileParser(logger)
+	result, err := logParser.ParseLogFile(logFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse log file %s: %w", logFilePath, err)
+	}
+
+	encodedBatches := make([][]byte, 0)
+
+	for _, batch := range result.RecordBatches {
+		as := serializer.GetEncodedBytes(batch)
+		encodedBatches = append(encodedBatches, as)
+	}
+
+	logger.Infof("Found %d RecordBatches in %s", len(result.RecordBatches), logFilePath)
+	return encodedBatches, nil
+}
+
+func encodeMultipleRecordBatches(recordBatches []kafkaapi.RecordBatch) [][]byte {
+	encodedBatches := make([][]byte, 0)
+	for i, recordBatch := range recordBatches {
+		recordBatch.BaseOffset = int64(i)
+		as := serializer.GetEncodedBytes(recordBatch)
+		encodedBatches = append(encodedBatches, as)
+	}
+	return encodedBatches
+}

--- a/internal/assertions/log_assertion.go
+++ b/internal/assertions/log_assertion.go
@@ -90,5 +90,5 @@ func findMisMatchOffset(expectedBytes []byte, actualBytes []byte) int {
 			return i
 		}
 	}
-	panic("Codecrafters Internal Error: No mismatch found")
+	return len(expectedBytes)
 }

--- a/internal/assertions/log_assertion.go
+++ b/internal/assertions/log_assertion.go
@@ -28,64 +28,48 @@ func NewTopicPartitionLogAssertion(topic string, partition int32, recordBatches 
 }
 
 func (a TopicPartitionLogAssertion) Run() error {
-	a.logger.UpdateLastSecondaryPrefix("logparser")
-	actualEncodedRecordBatches, err := encodeRecordBatchesInLogFile(a.topic, a.partition, a.logger)
-	a.logger.ResetSecondaryPrefixes()
+	logFilePath := getLogFilePathForTopic(a.topic, a.partition)
+	logParser := logparser.NewLogFileParser(logFilePath)
+
+	err := logParser.ReadLogFile(a.logger)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to read log file %s: %w", logFilePath, err)
 	}
 
-	expectedEncodedBatches := encodeMultipleRecordBatches(a.RecordBatches)
-
-	if len(actualEncodedRecordBatches) != len(expectedEncodedBatches) {
-		return fmt.Errorf("Expected %d RecordBatches in log file, got %d", len(expectedEncodedBatches), len(actualEncodedRecordBatches))
+	expectedEncodedRecordBatches := encodeRecordBatches(a.RecordBatches)
+	if len(expectedEncodedRecordBatches) == 0 {
+		panic("Codecrafters Internal Error: RecordBatches are empty")
 	}
 
-	for i, actualEncodedRecordBatch := range actualEncodedRecordBatches {
-		expectedEncodedRecordBatch := expectedEncodedBatches[i]
-		if !bytes.Equal(actualEncodedRecordBatch, expectedEncodedRecordBatch) {
-			fmt.Println("actualEncodedRecordBatch", actualEncodedRecordBatch)
-			fmt.Println("expectedEncodedRecordBatch", expectedEncodedRecordBatch)
-			return fmt.Errorf("RecordBatches in log file do not match expected RecordBatches")
+	if bytes.Equal(expectedEncodedRecordBatches, logParser.RawBytes) {
+		a.logger.Successf("✓ RecordBatches in log file (%s) match expected RecordBatches", logFilePath)
+		return nil
+	}
+
+	finalErr := fmt.Errorf("RecordBatches in log file (%s) do not match expected RecordBatches", logFilePath)
+
+	a.logger.UpdateLastSecondaryPrefix("logparser")
+	defer a.logger.ResetSecondaryPrefixes()
+
+	err = logParser.ParseLogFile(a.logger)
+	if err != nil {
+		return fmt.Errorf("Failed to parse log file (%s): %w", logFilePath, err)
+	}
+
+	if len(logParser.RecordBatches) != len(a.RecordBatches) {
+		return fmt.Errorf("Expected %d RecordBatches in log file (%s), got %d", len(a.RecordBatches), logFilePath, len(logParser.RecordBatches))
+	}
+
+	for i, actualRecordBatch := range logParser.RecordBatches {
+		expectedRecordBatch := a.RecordBatches[i]
+		if !bytes.Equal(serializer.GetEncodedBytes(actualRecordBatch), serializer.GetEncodedBytes(expectedRecordBatch)) {
+			return fmt.Errorf("RecordBatches in log file (%s) do not match expected RecordBatches", logFilePath)
 		}
 	}
 
-	a.logger.Successf("✓ RecordBatches in log file match expected RecordBatches")
-
-	return nil
+	return finalErr
 }
 
-// getLogFilePathForTopic builds the log file path for a given topic and partition
 func getLogFilePathForTopic(topicName string, partition int32) string {
 	return fmt.Sprintf("%s/%s-%d/00000000000000000000.log", common.LOG_DIR, topicName, partition)
-}
-
-func encodeRecordBatchesInLogFile(topicName string, partition int32, logger *logger.Logger) ([][]byte, error) {
-	logFilePath := getLogFilePathForTopic(topicName, partition)
-
-	logParser := logparser.NewLogFileParser(logger)
-	result, err := logParser.ParseLogFile(logFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse log file %s: %w", logFilePath, err)
-	}
-
-	encodedBatches := make([][]byte, 0)
-
-	for _, batch := range result.RecordBatches {
-		as := serializer.GetEncodedBytes(batch)
-		encodedBatches = append(encodedBatches, as)
-	}
-
-	logger.Infof("Found %d RecordBatches in %s", len(result.RecordBatches), logFilePath)
-	return encodedBatches, nil
-}
-
-func encodeMultipleRecordBatches(recordBatches []kafkaapi.RecordBatch) [][]byte {
-	encodedBatches := make([][]byte, 0)
-	for i, recordBatch := range recordBatches {
-		recordBatch.BaseOffset = int64(i)
-		as := serializer.GetEncodedBytes(recordBatch)
-		encodedBatches = append(encodedBatches, as)
-	}
-	return encodedBatches
 }

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -47,12 +47,12 @@ func (a *ProduceResponseAssertion) ExcludePartitionFields(fields ...string) *Pro
 }
 
 func (a *ProduceResponseAssertion) SkipTopicFields() *ProduceResponseAssertion {
-	a.excludedBodyFields = append(a.excludedBodyFields, "topics")
+	a.excludedBodyFields = append(a.excludedBodyFields, "Topics")
 	return a
 }
 
 func (a *ProduceResponseAssertion) SkipPartitionFields() *ProduceResponseAssertion {
-	a.excludedTopicFields = append(a.excludedTopicFields, "partitions")
+	a.excludedTopicFields = append(a.excludedTopicFields, "Partitions")
 	return a
 }
 
@@ -64,7 +64,7 @@ func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 		protocol.SuccessLogWithIndentation(logger, 0, "✓ ThrottleTimeMs: %d", a.ActualValue.Body.ThrottleTimeMs)
 	}
 
-	if !Contains(a.excludedBodyFields, "topics") {
+	if !Contains(a.excludedBodyFields, "Topics") {
 		if err := a.assertTopics(logger); err != nil {
 			return err
 		}
@@ -91,7 +91,7 @@ func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
 		expectedPartitions := expectedTopic.PartitionResponses
 		actualPartitions := actualTopic.PartitionResponses
 
-		if !Contains(a.excludedTopicFields, "partitions") {
+		if !Contains(a.excludedTopicFields, "Partitions") {
 			if err := a.assertPartitions(expectedPartitions, actualPartitions, logger); err != nil {
 				return err
 			}

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -14,7 +14,7 @@ type ProduceResponseAssertion struct {
 	ExpectedValue kafkaapi.ProduceResponse
 }
 
-func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponse, expectedValue kafkaapi.ProduceResponse, logger *logger.Logger) *ProduceResponseAssertion {
+func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponse, expectedValue kafkaapi.ProduceResponse) *ProduceResponseAssertion {
 	// Sort both responses for consistent comparison
 	actualValue.Body = sortResponseBodies(actualValue.Body)
 	expectedValue.Body = sortResponseBodies(expectedValue.Body)
@@ -27,9 +27,9 @@ func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponse, expectedV
 
 func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 	if a.ActualValue.Body.ThrottleTimeMs != a.ExpectedValue.Body.ThrottleTimeMs {
-		return fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.Body.ThrottleTimeMs, a.ActualValue.Body.ThrottleTimeMs)
+		return fmt.Errorf("Expected throttle_time_ms to be %d, got %d", a.ExpectedValue.Body.ThrottleTimeMs, a.ActualValue.Body.ThrottleTimeMs)
 	}
-	protocol.SuccessLogWithIndentation(logger, 0, "✓ ThrottleTimeMs: %d", a.ActualValue.Body.ThrottleTimeMs)
+	protocol.SuccessLogWithIndentation(logger, 0, "✓ throttle_time_ms: %d", a.ActualValue.Body.ThrottleTimeMs)
 
 	if err := a.assertTopics(logger); err != nil {
 		return err
@@ -40,16 +40,16 @@ func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 
 func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
 	if len(a.ActualValue.Body.TopicResponses) != len(a.ExpectedValue.Body.TopicResponses) {
-		return fmt.Errorf("Expected Topics.length to be %d, got %d", len(a.ExpectedValue.Body.TopicResponses), len(a.ActualValue.Body.TopicResponses))
+		return fmt.Errorf("Expected responses.length to be %d, got %d", len(a.ExpectedValue.Body.TopicResponses), len(a.ActualValue.Body.TopicResponses))
 	}
 
 	for i, actualTopic := range a.ActualValue.Body.TopicResponses {
 		expectedTopic := a.ExpectedValue.Body.TopicResponses[i]
 
 		if actualTopic.Name != expectedTopic.Name {
-			return fmt.Errorf("Expected TopicResponse[%d] Name to be %s, got %s", i, expectedTopic.Name, actualTopic.Name)
+			return fmt.Errorf("Expected responses[%d].name to be %s, got %s", i, expectedTopic.Name, actualTopic.Name)
 		}
-		protocol.SuccessLogWithIndentation(logger, 1, "✓ TopicResponse[%d] Name: %s", i, actualTopic.Name)
+		protocol.SuccessLogWithIndentation(logger, 1, "✓ responses[%d].name: %s", i, actualTopic.Name)
 
 		expectedPartitions := expectedTopic.PartitionResponses
 		actualPartitions := actualTopic.PartitionResponses
@@ -64,14 +64,14 @@ func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
 
 func (a *ProduceResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.ProducePartitionResponse, actualPartitions []kafkaapi.ProducePartitionResponse, logger *logger.Logger) error {
 	if len(actualPartitions) != len(expectedPartitions) {
-		return fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
+		return fmt.Errorf("Expected partition_responses.length to be %d, got %d", len(expectedPartitions), len(actualPartitions))
 	}
 
 	for j, actualPartition := range actualPartitions {
 		expectedPartition := expectedPartitions[j]
 
 		if actualPartition.ErrorCode != expectedPartition.ErrorCode {
-			return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
+			return fmt.Errorf("Expected partition_responses[%d].error_code to be %d, got %d", j, expectedPartition.ErrorCode, actualPartition.ErrorCode)
 		}
 
 		errorCodeName, ok := errorCodes[int(actualPartition.ErrorCode)]
@@ -79,27 +79,27 @@ func (a *ProduceResponseAssertion) assertPartitions(expectedPartitions []kafkaap
 			panic(fmt.Sprintf("CodeCrafters Internal Error: Expected %d to be in errorCodes map", actualPartition.ErrorCode))
 		}
 
-		protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] ErrorCode: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
+		protocol.SuccessLogWithIndentation(logger, 2, "✓ partition_responses[%d].error_code: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
 
 		if actualPartition.Index != expectedPartition.Index {
-			return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Index", j), expectedPartition.Index, actualPartition.Index)
+			return fmt.Errorf("Expected partition_responses[%d].index to be %d, got %d", j, expectedPartition.Index, actualPartition.Index)
 		}
-		protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] Index: %d", j, actualPartition.Index)
+		protocol.SuccessLogWithIndentation(logger, 2, "✓ partition_responses[%d].index: %d", j, actualPartition.Index)
 
 		if actualPartition.BaseOffset != expectedPartition.BaseOffset {
-			return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] BaseOffset", j), expectedPartition.BaseOffset, actualPartition.BaseOffset)
+			return fmt.Errorf("Expected partition_responses[%d].base_offset to be %d, got %d", j, expectedPartition.BaseOffset, actualPartition.BaseOffset)
 		}
-		protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] BaseOffset: %d", j, actualPartition.BaseOffset)
+		protocol.SuccessLogWithIndentation(logger, 2, "✓ partition_responses[%d].base_offset: %d", j, actualPartition.BaseOffset)
 
 		if actualPartition.LogStartOffset != expectedPartition.LogStartOffset {
-			return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogStartOffset", j), expectedPartition.LogStartOffset, actualPartition.LogStartOffset)
+			return fmt.Errorf("Expected partition_responses[%d].log_start_offset to be %d, got %d", j, expectedPartition.LogStartOffset, actualPartition.LogStartOffset)
 		}
-		protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] LogStartOffset: %d", j, actualPartition.LogStartOffset)
+		protocol.SuccessLogWithIndentation(logger, 2, "✓ partition_responses[%d].log_start_offset: %d", j, actualPartition.LogStartOffset)
 
 		if actualPartition.LogAppendTimeMs != expectedPartition.LogAppendTimeMs {
-			return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogAppendTimeMs", j), expectedPartition.LogAppendTimeMs, actualPartition.LogAppendTimeMs)
+			return fmt.Errorf("Expected partition_responses[%d].log_append_time_ms to be %d, got %d", j, expectedPartition.LogAppendTimeMs, actualPartition.LogAppendTimeMs)
 		}
-		protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] LogAppendTimeMs: %d", j, actualPartition.LogAppendTimeMs)
+		protocol.SuccessLogWithIndentation(logger, 2, "✓ partition_responses[%d].log_append_time_ms: %d", j, actualPartition.LogAppendTimeMs)
 	}
 
 	return nil

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -61,7 +61,7 @@ func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 		if a.ActualValue.Body.ThrottleTimeMs != a.ExpectedValue.Body.ThrottleTimeMs {
 			return fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.Body.ThrottleTimeMs, a.ActualValue.Body.ThrottleTimeMs)
 		}
-		protocol.SuccessLogWithIndentation(logger, 0, "✓ Throttle Time: %d", a.ActualValue.Body.ThrottleTimeMs)
+		protocol.SuccessLogWithIndentation(logger, 0, "✓ ThrottleTimeMs: %d", a.ActualValue.Body.ThrottleTimeMs)
 	}
 
 	if !Contains(a.excludedBodyFields, "topics") {
@@ -75,7 +75,7 @@ func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
 
 func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
 	if len(a.ActualValue.Body.TopicResponses) != len(a.ExpectedValue.Body.TopicResponses) {
-		return fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.Body.TopicResponses), len(a.ActualValue.Body.TopicResponses))
+		return fmt.Errorf("Expected Topics.length to be %d, got %d", len(a.ExpectedValue.Body.TopicResponses), len(a.ActualValue.Body.TopicResponses))
 	}
 
 	for i, actualTopic := range a.ActualValue.Body.TopicResponses {
@@ -83,7 +83,7 @@ func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
 
 		if !Contains(a.excludedTopicFields, "Name") {
 			if actualTopic.Name != expectedTopic.Name {
-				return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Name", i), expectedTopic.Name, actualTopic.Name)
+				return fmt.Errorf("Expected TopicResponse[%d] Name to be %s, got %s", i, expectedTopic.Name, actualTopic.Name)
 			}
 			protocol.SuccessLogWithIndentation(logger, 1, "✓ TopicResponse[%d] Name: %s", i, actualTopic.Name)
 		}
@@ -119,7 +119,7 @@ func (a *ProduceResponseAssertion) assertPartitions(expectedPartitions []kafkaap
 				panic(fmt.Sprintf("CodeCrafters Internal Error: Expected %d to be in errorCodes map", actualPartition.ErrorCode))
 			}
 
-			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] Error code: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] ErrorCode: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
 		}
 
 		if !Contains(a.excludedPartitionFields, "Index") {

--- a/internal/assertions/produce_response_assertion.go
+++ b/internal/assertions/produce_response_assertion.go
@@ -1,0 +1,197 @@
+package assertions
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/codecrafters-io/kafka-tester/protocol"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type ProduceResponseAssertion struct {
+	ActualValue   kafkaapi.ProduceResponseBody
+	ExpectedValue kafkaapi.ProduceResponseBody
+
+	// empty slice = assert all fields (default)
+	// non-empty slice = assert with exclusions
+	// if excludedBodyFields contains "topics", then Topics are not asserted
+	// if excludedTopicFields contains "partitions", then Partitions are not asserted
+	excludedBodyFields      []string
+	excludedTopicFields     []string
+	excludedPartitionFields []string
+}
+
+func NewProduceResponseAssertion(actualValue kafkaapi.ProduceResponseBody, expectedValue kafkaapi.ProduceResponseBody, logger *logger.Logger) *ProduceResponseAssertion {
+	// Sort both responses for consistent comparison
+	// sortedActual := sortResponses(actualValue)
+	// sortedExpected := sortResponses(expectedValue)
+
+	return &ProduceResponseAssertion{
+		ActualValue:             actualValue,
+		ExpectedValue:           expectedValue,
+		excludedBodyFields:      []string{},
+		excludedTopicFields:     []string{},
+		excludedPartitionFields: []string{},
+	}
+}
+
+func (a *ProduceResponseAssertion) ExcludeBodyFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedBodyFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) ExcludeTopicFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedTopicFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) ExcludePartitionFields(fields ...string) *ProduceResponseAssertion {
+	a.excludedPartitionFields = fields
+	return a
+}
+
+func (a *ProduceResponseAssertion) SkipTopicFields() *ProduceResponseAssertion {
+	a.excludedBodyFields = append(a.excludedBodyFields, "topics")
+	return a
+}
+
+func (a *ProduceResponseAssertion) SkipPartitionFields() *ProduceResponseAssertion {
+	a.excludedTopicFields = append(a.excludedTopicFields, "partitions")
+	return a
+}
+
+func (a *ProduceResponseAssertion) assertBody(logger *logger.Logger) error {
+	if !Contains(a.excludedBodyFields, "ThrottleTimeMs") {
+		if a.ActualValue.ThrottleTimeMs != a.ExpectedValue.ThrottleTimeMs {
+			return fmt.Errorf("Expected %s to be %d, got %d", "ThrottleTimeMs", a.ExpectedValue.ThrottleTimeMs, a.ActualValue.ThrottleTimeMs)
+		}
+		protocol.SuccessLogWithIndentation(logger, 0, "✓ Throttle Time: %d", a.ActualValue.ThrottleTimeMs)
+	}
+
+	if !Contains(a.excludedBodyFields, "topics") {
+		if err := a.assertTopics(logger); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *ProduceResponseAssertion) assertTopics(logger *logger.Logger) error {
+	if len(a.ActualValue.TopicResponses) != len(a.ExpectedValue.TopicResponses) {
+		return fmt.Errorf("Expected %s to be %d, got %d", "topics.length", len(a.ExpectedValue.TopicResponses), len(a.ActualValue.TopicResponses))
+	}
+
+	for i, actualTopic := range a.ActualValue.TopicResponses {
+		expectedTopic := a.ExpectedValue.TopicResponses[i]
+
+		if !Contains(a.excludedTopicFields, "Name") {
+			if actualTopic.Name != expectedTopic.Name {
+				return fmt.Errorf("Expected %s to be %s, got %s", fmt.Sprintf("TopicResponse[%d] Name", i), expectedTopic.Name, actualTopic.Name)
+			}
+			protocol.SuccessLogWithIndentation(logger, 1, "✓ TopicResponse[%d] Name: %s", i, actualTopic.Name)
+		}
+
+		expectedPartitions := expectedTopic.PartitionResponses
+		actualPartitions := actualTopic.PartitionResponses
+
+		if !Contains(a.excludedTopicFields, "partitions") {
+			if err := a.assertPartitions(expectedPartitions, actualPartitions, logger); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (a *ProduceResponseAssertion) assertPartitions(expectedPartitions []kafkaapi.ProducePartitionResponse, actualPartitions []kafkaapi.ProducePartitionResponse, logger *logger.Logger) error {
+	if len(actualPartitions) != len(expectedPartitions) {
+		return fmt.Errorf("Expected %s to be %d, got %d", "partitions.length", len(expectedPartitions), len(actualPartitions))
+	}
+
+	for j, actualPartition := range actualPartitions {
+		expectedPartition := expectedPartitions[j]
+
+		if !Contains(a.excludedPartitionFields, "ErrorCode") {
+			if actualPartition.ErrorCode != expectedPartition.ErrorCode {
+				return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("PartitionResponse[%d] Error Code", j), expectedPartition.ErrorCode, actualPartition.ErrorCode)
+			}
+
+			errorCodeName, ok := errorCodes[int(actualPartition.ErrorCode)]
+			if !ok {
+				panic(fmt.Sprintf("CodeCrafters Internal Error: Expected %d to be in errorCodes map", actualPartition.ErrorCode))
+			}
+
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] Error code: %d (%s)", j, actualPartition.ErrorCode, errorCodeName)
+		}
+
+		if !Contains(a.excludedPartitionFields, "Index") {
+			if actualPartition.Index != expectedPartition.Index {
+				return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] Index", j), expectedPartition.Index, actualPartition.Index)
+			}
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] Index: %d", j, actualPartition.Index)
+		}
+
+		if !Contains(a.excludedPartitionFields, "BaseOffset") {
+			if actualPartition.BaseOffset != expectedPartition.BaseOffset {
+				return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] BaseOffset", j), expectedPartition.BaseOffset, actualPartition.BaseOffset)
+			}
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] BaseOffset: %d", j, actualPartition.BaseOffset)
+		}
+
+		if !Contains(a.excludedPartitionFields, "LogStartOffset") {
+			if actualPartition.LogStartOffset != expectedPartition.LogStartOffset {
+				return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogStartOffset", j), expectedPartition.LogStartOffset, actualPartition.LogStartOffset)
+			}
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] LogStartOffset: %d", j, actualPartition.LogStartOffset)
+		}
+
+		if !Contains(a.excludedPartitionFields, "LogAppendTimeMs") {
+			if actualPartition.LogAppendTimeMs != expectedPartition.LogAppendTimeMs {
+				return fmt.Errorf("Expected %s to be %d, got %d", fmt.Sprintf("Partition Response[%d] LogAppendTimeMs", j), expectedPartition.LogAppendTimeMs, actualPartition.LogAppendTimeMs)
+			}
+			protocol.SuccessLogWithIndentation(logger, 2, "✓ PartitionResponse[%d] LogAppendTimeMs: %d", j, actualPartition.LogAppendTimeMs)
+		}
+	}
+
+	return nil
+}
+
+func (a *ProduceResponseAssertion) Run(logger *logger.Logger) error {
+	// firstLevelFields: ["ThrottleTimeMs"]
+	// secondLevelFields (Topics): ["Name"]
+	// thirdLevelFields (Partitions): ["ErrorCode", "Index", "BaseOffset", "LogStartOffset", "LogAppendTimeMs"]
+	if err := a.assertBody(logger); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// sortResponses sorts topics by name and partitions within each topic by index
+func sortResponses(response kafkaapi.ProduceResponseBody) kafkaapi.ProduceResponseBody {
+	sortedResponse := response
+	sortedResponse.TopicResponses = make([]kafkaapi.ProduceTopicResponse, len(response.TopicResponses))
+	copy(sortedResponse.TopicResponses, response.TopicResponses)
+
+	// Sort topics by name
+	sort.Slice(sortedResponse.TopicResponses, func(i, j int) bool {
+		return sortedResponse.TopicResponses[i].Name < sortedResponse.TopicResponses[j].Name
+	})
+
+	// Sort partitions within each topic by index
+	for i := range sortedResponse.TopicResponses {
+		partitions := make([]kafkaapi.ProducePartitionResponse, len(sortedResponse.TopicResponses[i].PartitionResponses))
+		copy(partitions, sortedResponse.TopicResponses[i].PartitionResponses)
+
+		sort.Slice(partitions, func(x, y int) bool {
+			return partitions[x].Index < partitions[y].Index
+		})
+
+		sortedResponse.TopicResponses[i].PartitionResponses = partitions
+	}
+
+	return sortedResponse
+}

--- a/internal/logparser/log_parser.go
+++ b/internal/logparser/log_parser.go
@@ -1,0 +1,87 @@
+package logparser
+
+import (
+	"fmt"
+	"os"
+
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/decoder"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type LogFileParser struct {
+	logger *logger.Logger
+}
+
+// LogFileResult contains the parsed data from a log file
+type LogFileResult struct {
+	FilePath      string
+	RecordBatches []kafkaapi.RecordBatch
+	Messages      []string
+	TotalRecords  int
+}
+
+func NewLogFileParser(logger *logger.Logger) *LogFileParser {
+	return &LogFileParser{
+		logger: logger,
+	}
+}
+
+func (p *LogFileParser) ParseLogFile(filePath string) (*LogFileResult, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s: %w", filePath, err)
+	}
+
+	if len(data) == 0 {
+		p.logger.Debugf("File %s is empty", filePath)
+		return &LogFileResult{
+			FilePath:      filePath,
+			RecordBatches: []kafkaapi.RecordBatch{},
+			Messages:      []string{},
+			TotalRecords:  0,
+		}, nil
+	}
+
+	return p.parseLogData(filePath, data)
+}
+
+func (p *LogFileParser) parseLogData(filePath string, data []byte) (*LogFileResult, error) {
+	realDecoder := &decoder.Decoder{}
+	realDecoder.Init(data)
+
+	result := &LogFileResult{
+		FilePath:      filePath,
+		RecordBatches: []kafkaapi.RecordBatch{},
+		Messages:      []string{},
+		TotalRecords:  0,
+	}
+
+	batchIndex := 0
+	for realDecoder.Remaining() > 0 {
+		recordBatch := kafkaapi.RecordBatch{}
+
+		p.logger.Debugf("Decoding RecordBatch[%d] at offset %d", batchIndex, realDecoder.Offset())
+
+		err := recordBatch.Decode(realDecoder, p.logger, 1)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding record batch %d: %w", batchIndex, err)
+		}
+
+		result.RecordBatches = append(result.RecordBatches, recordBatch)
+
+		for _, record := range recordBatch.Records {
+			if record.Value != nil {
+				result.Messages = append(result.Messages, string(record.Value))
+			}
+			result.TotalRecords++
+		}
+
+		batchIndex++
+	}
+
+	p.logger.Debugf("Successfully decoded %d record batches with %d total records",
+		len(result.RecordBatches), result.TotalRecords)
+
+	return result, nil
+}

--- a/internal/logparser/log_parser.go
+++ b/internal/logparser/log_parser.go
@@ -36,16 +36,16 @@ func (p *LogFileParser) ReadLogFile(logger *logger.Logger) error {
 }
 
 func (p *LogFileParser) ParseLogFile(logger *logger.Logger) error {
-	realDecoder := &decoder.Decoder{}
-	realDecoder.Init(p.RawBytes)
+	decoder := &decoder.Decoder{}
+	decoder.Init(p.RawBytes)
 
 	batchIndex := 0
-	for realDecoder.Remaining() > 0 {
+	for decoder.Remaining() > 0 {
 		recordBatch := kafkaapi.RecordBatch{}
 
-		logger.Debugf("Decoding RecordBatch[%d] at offset %d", batchIndex, realDecoder.Offset())
+		logger.Infof("Decoding RecordBatch[%d] at offset %d", batchIndex, decoder.Offset())
 
-		err := recordBatch.Decode(realDecoder, logger, 1)
+		err := recordBatch.Decode(decoder, logger, 1)
 		if err != nil {
 			return fmt.Errorf("Error decoding record batch %d: %w", batchIndex, err)
 		}
@@ -54,7 +54,7 @@ func (p *LogFileParser) ParseLogFile(logger *logger.Logger) error {
 		batchIndex++
 	}
 
-	logger.Debugf("Successfully decoded %d record batches", len(p.RecordBatches))
+	logger.Infof("Successfully decoded %d record batches", len(p.RecordBatches))
 
 	return nil
 }

--- a/internal/stage_p2.go
+++ b/internal/stage_p2.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"github.com/codecrafters-io/kafka-tester/internal/assertions"
+	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+//lint:ignore U1000, ignore for this PR
+func testProduce2(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := kafka_executable.NewKafkaExecutable(stageHarness)
+	stageLogger := stageHarness.Logger
+	err := serializer.GenerateLogDirs(stageLogger, []string{})
+	if err != nil {
+		return err
+	}
+
+	if err := b.Run(); err != nil {
+		return err
+	}
+
+	correlationId := getRandomCorrelationId()
+
+	client := kafka_client.NewClient("localhost:9092")
+	if err := client.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer client.Close()
+
+	recordBatch := builder.NewRecordBatchBuilder().
+		AddStringRecord(common.MESSAGE1).
+		Build()
+
+	request := builder.NewProduceRequestBuilder().
+		AddRecordBatch(common.TOPIC_UNKOWN_NAME, 0, recordBatch).
+		WithCorrelationId(correlationId).
+		Build()
+
+	rawResponse, err := client.SendAndReceive(request, stageLogger)
+	if err != nil {
+		return err
+	}
+
+	actualResponse := builder.NewEmptyProduceResponse()
+	if err := actualResponse.Decode(rawResponse.Payload, stageLogger); err != nil {
+		return err
+	}
+
+	expectedResponse := builder.NewProduceResponseBuilder().
+		AddErrorPartitionResponse(common.TOPIC_UNKOWN_NAME, 0, 3).
+		WithCorrelationId(correlationId).
+		Build()
+
+	if err = assertions.NewProduceResponseAssertion(actualResponse, expectedResponse).Run(stageLogger); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/stage_p4.go
+++ b/internal/stage_p4.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"github.com/codecrafters-io/kafka-tester/internal/assertions"
+	"github.com/codecrafters-io/kafka-tester/internal/kafka_executable"
+	kafkaapi "github.com/codecrafters-io/kafka-tester/protocol/api"
+	"github.com/codecrafters-io/kafka-tester/protocol/builder"
+	"github.com/codecrafters-io/kafka-tester/protocol/common"
+	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
+	"github.com/codecrafters-io/kafka-tester/protocol/serializer"
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testProduce4(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := kafka_executable.NewKafkaExecutable(stageHarness)
+	stageLogger := stageHarness.Logger
+	err := serializer.GenerateLogDirs(stageLogger, []string{common.TOPIC4_NAME})
+	if err != nil {
+		return err
+	}
+
+	if err := b.Run(); err != nil {
+		return err
+	}
+
+	correlationId := getRandomCorrelationId()
+
+	client := kafka_client.NewClient("localhost:9092")
+	if err := client.ConnectWithRetries(b, stageLogger); err != nil {
+		return err
+	}
+	defer client.Close()
+
+	topic := common.TOPIC4_NAME
+	partition := int32(random.RandomInt(0, 3))
+
+	recordBatch := builder.NewRecordBatchBuilder().
+		AddStringRecord(common.MESSAGE1).
+		Build()
+
+	request := builder.NewProduceRequestBuilder().
+		AddRecordBatch(topic, partition, recordBatch).
+		WithCorrelationId(correlationId).
+		Build()
+
+	rawResponse, err := client.SendAndReceive(request, stageLogger)
+	if err != nil {
+		return err
+	}
+
+	actualResponse := builder.NewEmptyProduceResponse()
+	if err := actualResponse.Decode(rawResponse.Payload, stageLogger); err != nil {
+		return err
+	}
+
+	expectedResponse := builder.NewProduceResponseBuilder().
+		AddSuccessPartitionResponse(topic, partition).
+		WithCorrelationId(correlationId).
+		Build()
+
+	if err = assertions.NewProduceResponseAssertion(actualResponse, expectedResponse).Run(stageLogger); err != nil {
+		return err
+	}
+
+	topicPartitionLogAssertion := assertions.NewTopicPartitionLogAssertion(topic, partition, kafkaapi.RecordBatches{recordBatch})
+	if err = topicPartitionLogAssertion.Run(stageLogger); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Added ProduceResponseAssertion for flexible response validation  
- Introduced testProduce2 to validate produce request error handling  
- Unified produce response handling and assertions for consistency  
- Added Produce v7 test covering multi-topic multi-partition batches  
- Added produce stage tests and updated stage definitions  
- Fixed stage slugs from p2/p7 to p02/p07 for consistency  
- Added a 4th topic to support Produce tests with varied partition setups

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #88 
- <kbd>&nbsp;2&nbsp;</kbd> #84 
- <kbd>&nbsp;1&nbsp;</kbd> #80 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added functionality to verify that Kafka topic partition log files match expected record batches, with detailed error reporting and logging.
  * Introduced tools for comparing actual and expected Kafka ProduceResponse objects, including order-independent comparison and comprehensive validation.
  * Added the ability to read and parse Kafka log files, displaying decoding progress and errors for easier troubleshooting.
  * Implemented integration tests simulating Kafka produce requests, validating error responses for unknown topic partitions, and verifying successful produce operations with record batch assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->