### PR TITLE
Truncate bodyResponse to the actual number of bytes read

### DIFF
--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -40,6 +40,20 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/fetch/pass",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"apiversions_length_field_too_large": {
+			StageSlugs:          []string{"pv1"},
+			CodePath:            "./test_helpers/scenarios/apiversions_length_field_too_large",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/scenarios/apiversions_length_field_too_large",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
+		"apiversions_length_field_too_small": {
+			StageSlugs:          []string{"pv1"},
+			CodePath:            "./test_helpers/scenarios/apiversions_length_field_too_small",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/scenarios/apiversions_length_field_too_small",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 	}
 
 	tester_utils_testing.TestTesterOutput(t, testerDefinition, testCases)

--- a/internal/test_helpers/fixtures/scenarios/apiversions_length_field_too_large
+++ b/internal/test_helpers/fixtures/scenarios/apiversions_length_field_too_large
@@ -1,0 +1,32 @@
+Debug = true
+
+[33m[tester::#PV1] [0m[94mRunning tests for Stage #PV1 (pv1)[0m
+[33m[tester::#PV1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
+[33m[tester::#PV1] [0m[36mConnecting to broker at: localhost:9092[0m
+[33m[tester::#PV1] [0m[36mConnection to broker at localhost:9092 successful[0m
+[33m[tester::#PV1] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 177586623)[0m
+[33m[tester::#PV1] [0m[36mHexdump of sent "ApiVersions" request: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 26 00 12 00 04 0a 95 c1 bf 00 0c 6b 61 | ...&..........ka[0m
+[33m[tester::#PV1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 0a 6b 61 66 6b | fka-tester..kafk[0m
+[33m[tester::#PV1] [0m[36m0020 | 61 2d 63 6c 69 04 30 2e 31 00                   | a-cli.0.1.[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [0m[36mHexdump of received "ApiVersions" response: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 17 0a 95 c1 bf 00 00 02 00 12 00 00 00 | ................[0m
+[33m[tester::#PV1] [0m[36m0010 | 04 00 00 00 00 00 00                            | .......[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [0m[91m❌ Invalid response:[0m
+[33m[tester::#PV1] [0m[91mThe Message Size field does not match the length of the received payload.[0m
+[33m[tester::#PV1] [0m[91m🔍 Mismatch:[0m
+[33m[tester::#PV1] [0m[91mMessage Size field:      23 (Bytes: 00 00 00 17)[0m
+[33m[tester::#PV1] [0m[91mReceived payload length: 19[0m
+[33m[tester::#PV1] [0m[91m[0m
+[33m[tester::#PV1] [0m[91m💡 Hint:[0m
+[33m[tester::#PV1] [0m[91mThe Message Size field should not count itself.[0m
+[33m[tester::#PV1] [0m[91m[0m
+[33m[tester::#PV1] [0m[91mTest failed[0m
+[33m[tester::#PV1] [0m[36mTerminating program[0m
+[33m[tester::#PV1] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/scenarios/apiversions_length_field_too_small
+++ b/internal/test_helpers/fixtures/scenarios/apiversions_length_field_too_small
@@ -1,0 +1,45 @@
+Debug = true
+
+[33m[tester::#PV1] [0m[94mRunning tests for Stage #PV1 (pv1)[0m
+[33m[tester::#PV1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
+[33m[tester::#PV1] [0m[36mConnecting to broker at: localhost:9092[0m
+[33m[tester::#PV1] [0m[36mConnection to broker at localhost:9092 successful[0m
+[33m[tester::#PV1] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 177586623)[0m
+[33m[tester::#PV1] [0m[36mHexdump of sent "ApiVersions" request: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 26 00 12 00 04 0a 95 c1 bf 00 0c 6b 61 | ...&..........ka[0m
+[33m[tester::#PV1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 0a 6b 61 66 6b | fka-tester..kafk[0m
+[33m[tester::#PV1] [0m[36m0020 | 61 2d 63 6c 69 04 30 2e 31 00                   | a-cli.0.1.[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [0m[36mHexdump of received "ApiVersions" response: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 0f 0a 95 c1 bf 00 00 02 00 12 00 00 00 | ................[0m
+[33m[tester::#PV1] [0m[36m0010 | 04 00 00                                        | ...[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [Decoder] [0m[36m- .ResponseHeader[0m
+[33m[tester::#PV1] [Decoder] [0m[36m  - .correlation_id (177586623)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m- .ResponseBody[0m
+[33m[tester::#PV1] [Decoder] [0m[36m  - .error_code (0)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m  - .num_api_keys (1)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m  - .ApiKeys[0][0m
+[33m[tester::#PV1] [Decoder] [0m[36m    - .api_key (18)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m    - .min_version (0)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m    - .max_version (4)[0m
+[33m[tester::#PV1] [Decoder] [0m[36m    - .TAG_BUFFER[0m
+[33m[tester::#PV1] [0m[91mReceived:[0m
+[33m[tester::#PV1] [0m[91mHex (bytes 9-14)                                | ASCII[0m
+[33m[tester::#PV1] [0m[91m------------------------------------------------+------------------[0m
+[33m[tester::#PV1] [0m[91m00 00 00 04 00 00                               | ......[0m
+[33m[tester::#PV1] [0m[91m                ^                                      ^[0m
+[33m[tester::#PV1] [0m[91mError: Expected int32 length to be 4 bytes, got 1 bytes[0m
+[33m[tester::#PV1] [0m[91mContext:[0m
+[33m[tester::#PV1] [0m[91m- ApiVersions v4[0m
+[33m[tester::#PV1] [0m[91m  - Response Body[0m
+[33m[tester::#PV1] [0m[91m    - throttle_time_ms[0m
+[33m[tester::#PV1] [0m[91m      - INT32[0m
+[33m[tester::#PV1] [0m[91m[0m
+[33m[tester::#PV1] [0m[91mTest failed[0m
+[33m[tester::#PV1] [0m[36mTerminating program[0m
+[33m[tester::#PV1] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_large/codecrafters.yml
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_large/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_large/main.py
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_large/main.py
@@ -1,0 +1,57 @@
+import socket
+from binascii import hexlify
+from concurrent.futures import ThreadPoolExecutor
+from struct import pack, unpack
+from typing import NamedTuple
+
+
+class Request(NamedTuple):
+    length: int
+    api_key: int
+    api_version: int
+    correlation_id: int
+
+    @staticmethod
+    def from_bytes(raw: bytes) -> "Request":
+        length, api_key, api_version, correlation_id = unpack("!ihhi", raw[:12])
+        return Request(length, api_key, api_version, correlation_id)
+
+
+def main(port=9092):
+    server = socket.create_server(("localhost", port), reuse_port=True)
+    print(f"✌️ Listening on port {port}.")
+
+    with ThreadPoolExecutor() as executor:
+        while True:
+            connection, _ = server.accept()
+            executor.submit(handle_connection, connection)
+
+
+def handle_connection(connection) -> None:
+    with connection:
+        data = connection.recv(1024)
+        print("Received:", data, hexlify(data))
+
+        request = Request.from_bytes(data)
+        print(request)
+
+        hardcoded_apiversions_response = pack(
+            "!iihbhhhbib",
+            19 + 4,  # msg len
+            request.correlation_id,  # 4 bytes
+            0,  # error code,          2 bytes
+            2,  # varint,              1 byte
+            18,  # api key,            2 bytes
+            0,  # api min version,     2 bytes
+            4,  # api max version,     2 bytes
+            0,  # tag,                 1 bytes
+            0,  # throttle,            4 bytes
+            0,  # tag,                 1 bytes
+        )
+
+        print("Sending:", hardcoded_apiversions_response)
+        connection.sendall(hardcoded_apiversions_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_large/your_program.sh
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_large/your_program.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 $(dirname "$0")/main.py "$@"

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_small/codecrafters.yml
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_small/codecrafters.yml
@@ -1,0 +1,1 @@
+debug: true

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_small/main.py
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_small/main.py
@@ -1,0 +1,57 @@
+import socket
+from binascii import hexlify
+from concurrent.futures import ThreadPoolExecutor
+from struct import pack, unpack
+from typing import NamedTuple
+
+
+class Request(NamedTuple):
+    length: int
+    api_key: int
+    api_version: int
+    correlation_id: int
+
+    @staticmethod
+    def from_bytes(raw: bytes) -> "Request":
+        length, api_key, api_version, correlation_id = unpack("!ihhi", raw[:12])
+        return Request(length, api_key, api_version, correlation_id)
+
+
+def main(port=9092):
+    server = socket.create_server(("localhost", port), reuse_port=True)
+    print(f"✌️ Listening on port {port}.")
+
+    with ThreadPoolExecutor() as executor:
+        while True:
+            connection, _ = server.accept()
+            executor.submit(handle_connection, connection)
+
+
+def handle_connection(connection) -> None:
+    with connection:
+        data = connection.recv(1024)
+        print("Received:", data, hexlify(data))
+
+        request = Request.from_bytes(data)
+        print(request)
+
+        hardcoded_apiversions_response = pack(
+            "!iihbhhhbib",
+            19 - 4,  # msg len
+            request.correlation_id,  # 4 bytes
+            0,  # error code,          2 bytes
+            2,  # varint,              1 byte
+            18,  # api key,            2 bytes
+            0,  # api min version,     2 bytes
+            4,  # api max version,     2 bytes
+            0,  # tag,                 1 bytes
+            0,  # throttle,            4 bytes
+            0,  # tag,                 1 bytes
+        )
+
+        print("Sending:", hardcoded_apiversions_response)
+        connection.sendall(hardcoded_apiversions_response)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/test_helpers/scenarios/apiversions_length_field_too_small/your_program.sh
+++ b/internal/test_helpers/scenarios/apiversions_length_field_too_small/your_program.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 $(dirname "$0")/main.py "$@"


### PR DESCRIPTION
- Validate response length and handle partial reads by truncating bodyResponse to the actual number of bytes read.
- Improve connection retry logic and read handling.
- Add support for ApiVersions length field edge cases on servers with debug enabled.
- Add test scenarios and cases for ApiVersions length field validation errors.