### PR TITLE
Move request logging logic to client

### DIFF
--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafkaapi"
 	"github.com/codecrafters-io/kafka-tester/protocol/legacy_serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/request_encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -46,12 +45,7 @@ func testHardcodedCorrelationId(stageHarness *test_case_harness.TestCaseHarness)
 		},
 	}
 
-	message := request_encoder.Encode(request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-	err := client.Send(message)
-
-	if err != nil {
+	if err := client.Send(request, stageLogger); err != nil {
 		return err
 	}
 

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafkaapi"
 	"github.com/codecrafters-io/kafka-tester/protocol/legacy_serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/request_encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -46,12 +45,7 @@ func testCorrelationId(stageHarness *test_case_harness.TestCaseHarness) error {
 		},
 	}
 
-	message := request_encoder.Encode(request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-	err := client.Send(message)
-
-	if err != nil {
+	if err := client.Send(request, stageLogger); err != nil {
 		return err
 	}
 

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codecrafters-io/kafka-tester/protocol/kafka_client"
 	"github.com/codecrafters-io/kafka-tester/protocol/kafkaapi"
 	"github.com/codecrafters-io/kafka-tester/protocol/legacy_serializer"
-	"github.com/codecrafters-io/kafka-tester/protocol/request_encoder"
 	"github.com/codecrafters-io/kafka-tester/protocol/utils"
 	"github.com/codecrafters-io/tester-utils/logger"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -47,12 +46,7 @@ func testAPIVersionErrorCase(stageHarness *test_case_harness.TestCaseHarness) er
 		},
 	}
 
-	message := request_encoder.Encode(request)
-	stageLogger.Infof("Sending \"ApiVersions\" (version: %v) request (Correlation id: %v)", request.Header.ApiVersion, request.Header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"ApiVersions\" request: \n%v\n", utils.GetFormattedHexdump(message))
-	err := client.Send(message)
-
-	if err != nil {
+	if err := client.Send(request, stageLogger); err != nil {
 		return err
 	}
 

--- a/protocol/kafka_client/client.go
+++ b/protocol/kafka_client/client.go
@@ -88,19 +88,13 @@ func (c *Client) Close() error {
 func (c *Client) SendAndReceive(request kafka_interface.RequestI, stageLogger *logger.Logger) (Response, error) {
 	header := request.GetHeader()
 	apiName := utils.APIKeyToName(header.ApiKey)
-	message := request_encoder.Encode(request)
 
-	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiName, header.ApiVersion, header.CorrelationId)
-	stageLogger.Debugf("Hexdump of sent \"%s\" request: \n%v\n", apiName, utils.GetFormattedHexdump(message))
-
-	response := Response{}
-
-	err := c.Send(message)
+	err := c.Send(request, stageLogger)
 	if err != nil {
-		return response, err
+		return Response{}, err
 	}
 
-	response, err = c.Receive()
+	response, err := c.Receive()
 	if err != nil {
 		return response, err
 	}
@@ -110,7 +104,14 @@ func (c *Client) SendAndReceive(request kafka_interface.RequestI, stageLogger *l
 	return response, nil
 }
 
-func (c *Client) Send(message []byte) error {
+func (c *Client) Send(request kafka_interface.RequestI, stageLogger *logger.Logger) error {
+	header := request.GetHeader()
+	apiName := utils.APIKeyToName(header.ApiKey)
+	message := request_encoder.Encode(request)
+
+	stageLogger.Infof("Sending \"%s\" (version: %v) request (Correlation id: %v)", apiName, header.ApiVersion, header.CorrelationId)
+	stageLogger.Debugf("Hexdump of sent \"%s\" request: \n%v\n", apiName, utils.GetFormattedHexdump(message))
+
 	// Set a deadline for the write operation
 	err := c.conn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
 	if err != nil {


### PR DESCRIPTION
Extract the message encoding and logging into a new Send method that
accepts a RequestI and stageLogger. Update internal stages to use this
method instead of encoding and sending messages separately. This reduces
code duplication, simplifies request sending, and centralizes logging for
better maintainability and consistency.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #104 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #100 
<!-- GitButler Footer Boundary Bottom -->

