### PR TITLE
feat(test): add malformed ApiVersionsResponse test scenario

### DIFF
--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -26,6 +26,13 @@ func TestStages(t *testing.T) {
 			StdoutFixturePath:   "./test_helpers/fixtures/base/correlation_id_mismatch",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
+		"api_versions_malformed_response": {
+			StageSlugs:          []string{"pv1"},
+			CodePath:            "./test_helpers/scenarios/base/api_versions_malformed_response",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/base/api_versions_malformed_response",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
 		// Currently the tester crashes for this case, so commenting it out
 		// "wrong_array_length": {
 		// 	StageSlugs:          []string{"pv1"},

--- a/internal/test_helpers/fixtures/base/api_versions_malformed_response
+++ b/internal/test_helpers/fixtures/base/api_versions_malformed_response
@@ -1,0 +1,36 @@
+Debug = true
+
+[33m[tester::#PV1] [0m[94mRunning tests for Stage #PV1 (pv1)[0m
+[33m[tester::#PV1] [0m[94m$ ./your_program.sh /tmp/server.properties[0m
+[33m[tester::#PV1] [0m[36mConnecting to broker at: localhost:9092[0m
+[33m[your_program] [0mLogs from your program will appear here!
+[33m[your_program] [0mThis server responds with a malformed response. See 'INTENTIONAL ERROR' comments in response.go
+[33m[tester::#PV1] [0m[36mConnection to broker at localhost:9092 successful[0m
+[33m[tester::#PV1] [0m[94mSending "ApiVersions" (version: 4) request (Correlation id: 177586623)[0m
+[33m[tester::#PV1] [0m[36mHexdump of sent "ApiVersions" request: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 26 00 12 00 04 0a 95 c1 bf 00 0c 6b 61 | ...&..........ka[0m
+[33m[tester::#PV1] [0m[36m0010 | 66 6b 61 2d 74 65 73 74 65 72 00 0a 6b 61 66 6b | fka-tester..kafk[0m
+[33m[tester::#PV1] [0m[36m0020 | 61 2d 63 6c 69 04 30 2e 31 00                   | a-cli.0.1.[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [0m[36mHexdump of Received "ApiVersions" response: [0m
+[33m[tester::#PV1] [0m[36mIdx  | Hex                                             | ASCII[0m
+[33m[tester::#PV1] [0m[36m-----+-------------------------------------------------+-----------------[0m
+[33m[tester::#PV1] [0m[36m0000 | 00 00 00 0c 0a 95 c1 bf 00 00 02 00 12 00 00 01 | ................[0m
+[33m[tester::#PV1] [0m[36m[0m
+[33m[tester::#PV1] [Decoder] [0m[94m- ApiVersionsResponse[0m
+[33m[tester::#PV1] [Decoder] [0m[94m  - Header[0m
+[33m[tester::#PV1] [Decoder] [0m[94m    - CorrelationID (177586623)[0m
+[33m[tester::#PV1] [Decoder] [0m[94m  - Body[0m
+[33m[tester::#PV1] [Decoder] [0m[94m    - ErrorCode (0)[0m
+[33m[tester::#PV1] [Decoder] [0m[94m    - ApiKeys[0m
+[33m[tester::#PV1] [Decoder] [0m[94m      - Length (1)[0m
+[33m[tester::#PV1] [Decoder] [0m[94m      - ApiKeys[0][0m
+[33m[tester::#PV1] [Decoder] [0m[94m        - APIKey (18)[0m
+[33m[tester::#PV1] [Decoder] [0m[94m        - MinVersion (0)[0m
+[33m[tester::#PV1] [Decoder] [0m[94m        ❌ MaxVersion (decode error)[0m
+[33m[tester::#PV1] [0m[91mExpected INT16 length to be 2 bytes, got 1 bytes[0m
+[33m[tester::#PV1] [0m[91mTest failed[0m
+[33m[tester::#PV1] [0m[36mTerminating program[0m
+[33m[tester::#PV1] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/go.mod
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.24.4

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/main.go
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+func main() {
+	fmt.Println("Logs from your program will appear here!")
+
+	// Listen on port 9092
+	listener, err := net.Listen("tcp", "0.0.0.0:9092")
+	if err != nil {
+		fmt.Printf("Failed to bind to port 9092\n")
+		os.Exit(1)
+	}
+	defer listener.Close()
+
+	fmt.Println("This server responds with a malformed response. See 'INTENTIONAL ERROR' comments in response.go")
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Printf("Error accepting connection: %v\n", err)
+			continue
+		}
+
+		go handleConnection(conn)
+	}
+}
+
+func handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	request, err := ParseRequest(reader)
+	if err != nil {
+		if err == io.EOF {
+			return
+		}
+		fmt.Printf("Error reading request: %v\n", err)
+		return
+	}
+
+	response := ProcessRequest(request)
+	_, err = conn.Write(response.Encode())
+
+	if err != nil {
+		fmt.Printf("Error sending response: %v\n", err)
+		return
+	}
+}

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/processing.go
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/processing.go
@@ -1,0 +1,37 @@
+package main
+
+import "fmt"
+
+const (
+	API_VERSIONS_KEY = 18
+)
+
+func ProcessRequest(request *Request) Response {
+	switch request.Header.ApiKey {
+	case API_VERSIONS_KEY:
+		return ProcessApiVersionsRequest(request)
+	default:
+		panic(fmt.Sprintf("API Key unrecognized: %d\n", request.Header.ApiKey))
+	}
+}
+
+func ProcessApiVersionsRequest(request *Request) *ApiVersionsResponse {
+	response := &ApiVersionsResponse{
+		Header: &ResponseHeader{
+			CorrelationID: request.Header.CorrelationID,
+		},
+		Body: ApiVersionsResponseBody{
+			ErrorCode: 0,
+			ApiKeyEntries: []ApiKeyEntry{
+				{
+					ApiKey:              API_VERSIONS_KEY, // API_VERSIONS
+					MinSupportedVersion: 0,
+					MaxSupportedVersion: 4,
+				},
+			},
+			ThrottleTimeMS: 0,
+		},
+	}
+
+	return response
+}

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/protocol.go
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/protocol.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+)
+
+// readInt32 reads a 4-byte big-endian integer from the reader
+func readInt32(reader *bufio.Reader) (int32, error) {
+	bytes := make([]byte, 4)
+	_, err := io.ReadFull(reader, bytes)
+	if err != nil {
+		return 0, err
+	}
+	return int32(binary.BigEndian.Uint32(bytes)), nil
+}
+
+// readInt16 reads a 2-byte big-endian integer from the reader
+func readInt16(reader *bufio.Reader) (int16, error) {
+	bytes := make([]byte, 2)
+	_, err := io.ReadFull(reader, bytes)
+	if err != nil {
+		return 0, err
+	}
+	return int16(binary.BigEndian.Uint16(bytes)), nil
+}
+
+// readRawBytes reads a specified number of bytes from the reader
+func readRawBytes(reader *bufio.Reader, length int) ([]byte, error) {
+	bytes := make([]byte, length)
+	_, err := io.ReadFull(reader, bytes)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// writeInt32 writes a 4-byte big-endian integer and returns the bytes
+func writeInt32(value int32) []byte {
+	bytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(bytes, uint32(value))
+	return bytes
+}
+
+// writeInt16 writes a 2-byte big-endian integer and returns the bytes
+func writeInt16(value int16) []byte {
+	bytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(bytes, uint16(value))
+	return bytes
+}
+
+// writeCompactArrayLength adds 1 to the length and converts to varint, returns the bytes
+func writeCompactArrayLength(length int) []byte {
+	arraySize := length + 1 // compact array length: actual_length + 1
+	varintBytes := make([]byte, binary.MaxVarintLen32)
+	varintLen := binary.PutUvarint(varintBytes, uint64(arraySize))
+	return varintBytes[:varintLen]
+}

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/request.go
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/request.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+)
+
+// Request
+type Request struct {
+	MessageSize int32
+	Header      *RequestHeader
+	// Body        RequestBody (Not needed in base stages)
+}
+
+// Request Header
+
+type RequestHeader struct {
+	ApiKey        int16
+	ApiVersion    int16
+	CorrelationID int32
+	ClientId      string
+}
+
+// We don't need Request body (for base stages)
+
+// ParseRequest reads and parses a Kafka request from the connection
+func ParseRequest(reader *bufio.Reader) (*Request, error) {
+	messageSize, err := readMessageSize(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read message size: %w", err)
+	}
+
+	requestHeader, err := parseRequestHeader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse request header: %w", err)
+	}
+
+	// Parse request body based on the header, but it's not needed in base stages
+
+	return &Request{
+		MessageSize: messageSize,
+		Header:      requestHeader,
+	}, nil
+}
+
+func readMessageSize(reader *bufio.Reader) (int32, error) {
+	return readInt32(reader)
+}
+
+func parseRequestHeader(reader *bufio.Reader) (header *RequestHeader, err error) {
+	header = &RequestHeader{}
+	// api key
+	if header.ApiKey, err = readInt16(reader); err != nil {
+		return nil, err
+	}
+
+	// api version
+	if header.ApiVersion, err = readInt16(reader); err != nil {
+		return nil, err
+	}
+
+	// correlation ID
+	if header.CorrelationID, err = readInt32(reader); err != nil {
+		return nil, err
+	}
+
+	// client ID length
+	var clientIdLength int16
+	if clientIdLength, err = readInt16(reader); err != nil {
+		return nil, err
+	}
+
+	// client ID
+	if clientIdLength > 0 {
+		clientIDBytes, err := readRawBytes(reader, int(clientIdLength))
+		if err != nil {
+			return nil, err
+		}
+		header.ClientId = string(clientIDBytes)
+	}
+
+	if _, err = readRawBytes(reader, 1); err != nil {
+		return nil, err
+	}
+
+	return header, nil
+}
+
+func EncodeResponse(response Response) []byte {
+	return response.Encode()
+}

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/response.go
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/app/response.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// Response
+
+func PackMessage(messageBytes []byte) []byte {
+	messageSize := len(messageBytes)
+
+	result := make([]byte, 4+messageSize)
+	binary.BigEndian.PutUint32(result[0:4], uint32(messageSize))
+	copy(result[4:], messageBytes)
+	return result
+}
+
+// Response Header
+
+type ResponseHeader struct {
+	CorrelationID int32
+}
+
+func (h *ResponseHeader) Encode() []byte {
+	return writeInt32(h.CorrelationID)
+}
+
+// Response
+
+type Response interface {
+	Encode() []byte
+}
+
+// ApiVersionsResponse
+
+type ApiVersionsResponse struct {
+	Header *ResponseHeader
+	Body   ApiVersionsResponseBody
+}
+
+func (r *ApiVersionsResponse) Encode() []byte {
+	return PackMessage(append(r.Header.Encode(), r.Body.Encode()...))
+}
+
+type ApiVersionsResponseBody struct {
+	ErrorCode      int16
+	ApiKeyEntries  []ApiKeyEntry
+	ThrottleTimeMS int32
+}
+
+func (a *ApiVersionsResponseBody) Encode() []byte {
+	var result bytes.Buffer
+
+	// error code
+	result.Write(writeInt16(a.ErrorCode))
+
+	// api entry size
+	result.Write(writeCompactArrayLength(len(a.ApiKeyEntries)))
+
+	// INTENTIONAL ERROR: We only write partial bytes, MaxSupportedVersion is missing
+	result.Write(writeInt16(a.ApiKeyEntries[0].ApiKey))
+	result.Write(writeInt16(a.ApiKeyEntries[0].MinSupportedVersion))
+	result.WriteByte(1) // Incomplete bytes for MaxSupportedVersion
+
+	return result.Bytes()
+}
+
+type ApiKeyEntry struct {
+	ApiKey              int16
+	MinSupportedVersion int16
+	MaxSupportedVersion int16
+}

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/codecrafters.yml
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/codecrafters.yml
@@ -1,0 +1,5 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: true

--- a/internal/test_helpers/scenarios/base/api_versions_malformed_response/your_program.sh
+++ b/internal/test_helpers/scenarios/base/api_versions_malformed_response/your_program.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# DON'T EDIT THIS!
+#
+# CodeCrafters uses this file to test your code. Don't make any changes here!
+#
+# DON'T EDIT THIS!
+set -e
+tmpFile=$(mktemp)
+
+(cd $(dirname "$0") &&
+    go build -o "$tmpFile" app/*.go)
+
+exec "$tmpFile"


### PR DESCRIPTION
Add a new test scenario that simulates a malformed ApiVersions response 
with incomplete MaxSupportedVersion bytes to verify decoder error handling. 

Implement ApiVersionsResponse encoding that intentionally omits part of the 
MaxSupportedVersion field to trigger decode failures in client code. 

Add supporting test scripts, fixtures, and configuration to run this scenario 
with debug enabled for detailed test output and diagnostics.